### PR TITLE
Bump version to 0.1.5 with Jaalee advertisement matching fixes.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "0.1.4"
+        versionCode = 6
+        versionName = "0.1.5"
     }
 
     buildTypes {

--- a/app/src/main/java/dev/eigger/hassble/ble/AdvertisementMatcher.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AdvertisementMatcher.kt
@@ -13,7 +13,7 @@ object AdvertisementMatcher {
         deviceAddress: String,
         deviceName: String,
         hasServiceUuid: (String) -> Boolean,
-        hasManufacturerId: (Int) -> Boolean,
+        manufacturerPayload: (Int) -> ByteArray?,
     ): Boolean {
         val checks = mutableListOf<() -> Boolean>()
 
@@ -27,7 +27,14 @@ object AdvertisementMatcher {
             checks += { deviceName.startsWith(prefix, ignoreCase = true) }
         }
         match.manufacturerId?.let { id ->
-            checks += { hasManufacturerId(id) }
+            checks += {
+                val payload = manufacturerPayload(id)
+                payload != null &&
+                    (match.manufacturerMinLength?.let { min -> payload.size >= min } ?: true) &&
+                    (match.manufacturerHexPrefix?.let { prefix ->
+                        bytesToHex(payload).startsWith(prefix, ignoreCase = true)
+                    } ?: true)
+            }
         }
 
         return checks.isNotEmpty() && checks.all { it() }

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -58,6 +58,7 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                 val deviceAddress = result.device.address
                 val scanRecord = result.data?.scanRecord
                 val serviceData = scanRecord?.serviceData ?: emptyMap()
+                val advertisedServiceUuids = scanRecord?.serviceUuids.orEmpty()
                 val manufacturerData = scanRecord?.manufacturerSpecificData
                 val rawBytes = scanRecord?.bytes
 
@@ -72,18 +73,19 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                             hasServiceUuid = { uuid ->
                                 val target = uuid.uppercase()
                                 serviceData.keys.any { it.uuid.toString().uppercase().contains(target) }
+                                    || advertisedServiceUuids.any {
+                                        it.uuid.toString().uppercase().contains(target)
+                                    }
                             },
-                            hasManufacturerId = { id ->
-                                manufacturerData?.get(id) != null
+                            manufacturerPayload = { id ->
+                                manufacturerData?.get(id)?.value?.takeIf { it.isNotEmpty() }
                             },
                         )
                     ) {
                         continue
                     }
 
-                    val manufacturerHex = match.manufacturerId?.let { id ->
-                        manufacturerData?.get(id)?.value?.let { AdvertisementMatcher.bytesToHex(it) }
-                    }
+                    val manufacturerHex = resolveManufacturerHex(manufacturerData, match.manufacturerId)
                     val serviceDataHex = match.serviceDataUuid?.let { uuid ->
                         val target = uuid.uppercase()
                         serviceData.entries.firstOrNull { (key, _) ->
@@ -125,6 +127,25 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
 
     private fun bytesToHex(bytes: ByteArray): String =
         bytes.joinToString("") { String.format("%02X", it) }
+
+    private fun resolveManufacturerHex(
+        manufacturerData: android.util.SparseArray<no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray>?,
+        preferredId: Int?,
+    ): String? {
+        preferredId?.let { id ->
+            manufacturerData?.get(id)?.value
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { return bytesToHex(it) }
+        }
+        if (manufacturerData == null || manufacturerData.size() == 0) return null
+        var best: ByteArray? = null
+        for (i in 0 until manufacturerData.size()) {
+            val payload = manufacturerData.valueAt(i)?.value ?: continue
+            if (payload.isEmpty()) continue
+            if (best == null || payload.size > best.size) best = payload
+        }
+        return best?.let { bytesToHex(it) }
+    }
 }
 
 /**

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -44,6 +44,10 @@ data class MatchConfig(
     val mac: String? = null,
     @SerialName("service_data_uuid") val serviceDataUuid: String? = null,
     @SerialName("manufacturer_id") val manufacturerId: Int? = null,
+    /** manufacturer payload(hex, 대소문자 무시)가 이 문자열로 시작해야 함. Jaalee iBeacon: 0215 */
+    @SerialName("manufacturer_hex_prefix") val manufacturerHexPrefix: String? = null,
+    /** manufacturer payload 최소 바이트 수. Jaalee JHT: 24 */
+    @SerialName("manufacturer_min_length") val manufacturerMinLength: Int? = null,
     @SerialName("name_prefix") val namePrefix: String? = null,
 )
 

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -860,18 +860,28 @@ private fun DeviceConfigCard(
                             modifier = Modifier.padding(top = 4.dp),
                         )
                     }
-                }
-                Column(horizontalAlignment = Alignment.End) {
-                    val badgeColor = when (device.source) { Source.advertisement -> Color(0xFF02B3E4); Source.gatt_notify -> Color(0xFF9E86FF); Source.obd -> Color(0xFFFF9100) }
-                    val badgeText = when (device.source) {
-                        Source.advertisement -> stringResource(R.string.source_advertisement)
-                        Source.gatt_notify -> stringResource(R.string.source_gatt_notify)
-                        Source.obd -> stringResource(R.string.source_obd)
-                    }
-                    SourceBadge(text = badgeText, color = badgeColor)
                     if (device.source == Source.advertisement) {
-                        Spacer(modifier = Modifier.height(4.dp))
-                        AdvertisementRegistrationBadge(device)
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            val badgeColor = Color(0xFF02B3E4)
+                            SourceBadge(
+                                text = stringResource(R.string.source_advertisement),
+                                color = badgeColor,
+                            )
+                            val reg = advertisementRegistrationKind(device)
+                            SourceBadge(text = reg.label, color = reg.color)
+                        }
+                    }
+                }
+                if (device.source != Source.advertisement) {
+                    Column(horizontalAlignment = Alignment.End) {
+                        val badgeColor = when (device.source) { Source.gatt_notify -> Color(0xFF9E86FF); Source.obd -> Color(0xFFFF9100); else -> Color.Gray }
+                        val badgeText = when (device.source) {
+                            Source.gatt_notify -> stringResource(R.string.source_gatt_notify)
+                            Source.obd -> stringResource(R.string.source_obd)
+                            else -> ""
+                        }
+                        SourceBadge(text = badgeText, color = badgeColor)
                     }
                 }
                 Icon(
@@ -1010,8 +1020,10 @@ private fun DeviceConfigCard(
                 when (device.source) {
                     Source.advertisement -> {
                         val reg = advertisementRegistrationKind(device)
-                        Text(text = reg.hint, color = Color.Gray, fontSize = 11.sp)
-                        Spacer(modifier = Modifier.height(8.dp))
+                        if (!isRunning) {
+                            Text(text = reg.hint, color = Color.Gray, fontSize = 11.sp)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
                         when {
                             !isRunning -> {
                                 Text(
@@ -1213,12 +1225,6 @@ private fun SourceBadge(text: String, color: Color) {
     ) {
         Text(text = text, color = color, fontSize = 11.sp, fontWeight = FontWeight.Bold)
     }
-}
-
-@Composable
-private fun AdvertisementRegistrationBadge(device: DeviceConfig) {
-    val reg = advertisementRegistrationKind(device)
-    SourceBadge(text = reg.label, color = reg.color)
 }
 
 @Composable

--- a/app/src/test/java/dev/eigger/hassble/ble/AdvertisementMatcherTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/AdvertisementMatcherTest.kt
@@ -7,6 +7,10 @@ import org.junit.Test
 
 class AdvertisementMatcherTest {
 
+    private val jaaleeManufacturer = hexToBytes(
+        "0215ebefd08370a247c89837e7b5634df52567ed9280cc4d",
+    )
+
     @Test
     fun `jaalee requires both service uuid and manufacturer id`() {
         val match = MatchConfig(serviceDataUuid = "F525", manufacturerId = 0x004C)
@@ -16,7 +20,7 @@ class AdvertisementMatcherTest {
                 "AA:BB:CC:DD:EE:FF",
                 "",
                 hasServiceUuid = { it.equals("F525", ignoreCase = true) },
-                hasManufacturerId = { it == 0x004C },
+                manufacturerPayload = { if (it == 0x004C) jaaleeManufacturer else null },
             ),
         )
     }
@@ -30,7 +34,7 @@ class AdvertisementMatcherTest {
                 "AA:BB:CC:DD:EE:FF",
                 "",
                 hasServiceUuid = { false },
-                hasManufacturerId = { it == 0x004C },
+                manufacturerPayload = { if (it == 0x004C) jaaleeManufacturer else null },
             ),
         )
     }
@@ -44,7 +48,48 @@ class AdvertisementMatcherTest {
                 "AA:BB:CC:DD:EE:FF",
                 "",
                 hasServiceUuid = { true },
-                hasManufacturerId = { false },
+                manufacturerPayload = { null },
+            ),
+        )
+    }
+
+    @Test
+    fun `f51c service with jaalee manufacturer matches`() {
+        val match = MatchConfig(serviceDataUuid = "F51C", manufacturerId = 0x004C)
+        assertTrue(
+            AdvertisementMatcher.matches(
+                match,
+                "DF:06:0F:CF:7C:33",
+                "",
+                hasServiceUuid = { it.equals("F51C", ignoreCase = true) },
+                manufacturerPayload = { if (it == 0x004C) jaaleeManufacturer else null },
+            ),
+        )
+    }
+
+    @Test
+    fun `jaalee fingerprint without service uuid`() {
+        val match = MatchConfig(
+            manufacturerId = 0x004C,
+            manufacturerHexPrefix = "0215EBEF",
+            manufacturerMinLength = 24,
+        )
+        assertTrue(
+            AdvertisementMatcher.matches(
+                match,
+                "DF:06:0F:CF:7C:33",
+                "",
+                hasServiceUuid = { false },
+                manufacturerPayload = { if (it == 0x004C) jaaleeManufacturer else null },
+            ),
+        )
+        assertFalse(
+            AdvertisementMatcher.matches(
+                match,
+                "DF:06:0F:CF:7C:33",
+                "",
+                hasServiceUuid = { false },
+                manufacturerPayload = { if (it == 0x004C) byteArrayOf(0x02, 0x15, 0x01) else null },
             ),
         )
     }
@@ -58,8 +103,11 @@ class AdvertisementMatcherTest {
                 "AA:BB:CC:DD:EE:FF",
                 "",
                 hasServiceUuid = { false },
-                hasManufacturerId = { it == 0x035D },
+                manufacturerPayload = { if (it == 0x035D) byteArrayOf(1, 2, 3) else null },
             ),
         )
     }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
 }

--- a/app/src/test/java/dev/eigger/hassble/decode/JaaleeDecodeTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/JaaleeDecodeTest.kt
@@ -1,0 +1,53 @@
+package dev.eigger.hassble.decode
+
+import dev.eigger.hassble.config.DataType
+import dev.eigger.hassble.config.DecodeConfig
+import dev.eigger.hassble.config.Endian
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class JaaleeDecodeTest {
+
+    /** 실기기 DF:06:0F:CF:7C:33 manufacturer payload (company ID 제외). */
+    private val manufacturerHex = "0215ebefd08370a247c89837e7b5634df52567ed9280cc4d"
+
+    @Test
+    fun `jaalee temperature humidity battery decode from manufacturer data`() {
+        val bytes = Decoder.hexToBytes(manufacturerHex)!!
+        assertEquals(24, bytes.size)
+
+        val temp = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(
+                offset = 18,
+                length = 2,
+                type = DataType.uint16,
+                endian = Endian.big,
+                scale = 0.002670288,
+                offsetValue = -45.0,
+            ),
+        ) as Double
+        val humidity = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(
+                offset = 20,
+                length = 2,
+                type = DataType.uint16,
+                endian = Endian.big,
+                scale = 0.001524504,
+            ),
+        ) as Double
+        val battery = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(offset = 23, length = 1, type = DataType.uint8),
+        )
+
+        assertNotNull(battery)
+        // 0x67ED=26605 → (26605/65535)*175-45 ≈ 26.0°C
+        assertEquals(26.0, temp, 0.5)
+        // 0x9280=37504 → (37504/65535)*100 ≈ 57.2%
+        assertEquals(57.2, humidity, 1.0)
+        assertEquals(77.0, (battery as Number).toDouble(), 0.01)
+    }
+}

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -43,8 +43,10 @@ devices: [ ... ]                    # 아래 참조
   instance_mode: mac           # mac(기본) | shared
   match:                       # 지정한 항목은 **모두** 일치해야 함 (AND)
     mac: "A4:C1:38:..."
-    service_data_uuid: "181a"
+    service_data_uuid: "181a"  # service_data 또는 광고 service_uuids 목록
     manufacturer_id: 0x004C
+    manufacturer_hex_prefix: "0215"      # 선택: manufacturer payload hex 접두사
+    manufacturer_min_length: 24          # 선택: manufacturer payload 최소 바이트
     name_prefix: "LYWSD"
   sensors:
     - key: temperature


### PR DESCRIPTION
- Match F51C service UUIDs and Jaalee iBeacon manufacturer fingerprint

- manufacturer_hex_prefix / manufacturer_min_length match options

- Fix advertisement sensor card UI overlap; Jaalee decode unit tests