### PR TITLE
Bump version to 0.1.6 with UI fixes, config inspector, and Jaalee par…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
-        versionName = "0.1.5"
+        versionCode = 7
+        versionName = "0.1.6"
     }
 
     buildTypes {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -178,7 +178,7 @@ class BleRuntime(
                     ensureAdvertisementInstance(d, mac, r.deviceName)
                 }
                 val instanceId = advertisementInstanceId(d, mac)
-                recordAdvertisementSeen(d, mac, r.deviceName, instanceId)
+                recordAdvertisementSeen(d, mac, r.deviceName, instanceId, r)
                 for (s in d.sensors) {
                     if (!isEnabled(d.id, s.key) || s.decode == null) continue
                     val bytes = advertisementPayloadBytes(r, s.sourceField) ?: continue
@@ -317,6 +317,7 @@ class BleRuntime(
         mac: String,
         deviceName: String?,
         instanceId: String,
+        reading: RawReading,
     ) {
         val key = "${d.id}|${normalizeMac(mac)}"
         discoveredAdvInstances[key] = DiscoveredAdvInstance(
@@ -325,6 +326,8 @@ class BleRuntime(
             deviceName = deviceName?.takeIf { it.isNotBlank() },
             instanceId = instanceId,
             lastSeenMs = System.currentTimeMillis(),
+            manufacturerHex = reading.manufacturerHex,
+            serviceDataHex = reading.serviceDataHex,
         )
         publishDiscoveredAdv()
     }

--- a/app/src/main/java/dev/eigger/hassble/ble/DiscoveredAdvInstance.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/DiscoveredAdvInstance.kt
@@ -7,4 +7,8 @@ data class DiscoveredAdvInstance(
     val deviceName: String?,
     val instanceId: String,
     val lastSeenMs: Long,
+    /** 마지막으로 수신한 manufacturer payload (company ID 제외) hex. 디코딩 진단용. */
+    val manufacturerHex: String? = null,
+    /** 마지막으로 수신한 service_data payload hex. */
+    val serviceDataHex: String? = null,
 )

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -308,12 +309,12 @@ private fun HomeScreen() {
     var scanningDevice by remember { mutableStateOf<DeviceConfig?>(null) }
     var selectedTab by remember { mutableStateOf(0) }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
         if (missingPermCount > 0) {
             PermissionBanner(missingCount = missingPermCount)
         }
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
@@ -1017,6 +1018,7 @@ private fun DeviceConfigCard(
                             .background(Color.Black.copy(alpha = 0.2f))
                             .padding(12.dp),
                     ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
                 when (device.source) {
                     Source.advertisement -> {
                         val reg = advertisementRegistrationKind(device)
@@ -1169,11 +1171,108 @@ private fun DeviceConfigCard(
                         }
                     }
                 }
+                }
                     }
+
+                    ConfigDetailSection(
+                        device = device,
+                        discoveredInstances = discoveredInstances,
+                    )
                 }
             }
         }
     }
+}
+
+@Composable
+private fun ConfigDetailSection(
+    device: DeviceConfig,
+    discoveredInstances: List<DiscoveredAdvInstance>,
+) {
+    var open by remember(device.id) { mutableStateOf(false) }
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = stringResource(if (open) R.string.config_detail_hide else R.string.config_detail_show),
+        color = MaterialTheme.colorScheme.primary,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+            .clickable { open = !open }
+            .padding(vertical = 4.dp),
+    )
+    if (!open) return
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Black.copy(alpha = 0.25f))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        device.match?.let { m ->
+            val criteria = buildList {
+                m.mac?.let { add("mac=$it") }
+                m.serviceDataUuid?.let { add("service_uuid=$it") }
+                m.manufacturerId?.let { add("manufacturer_id=0x%04X".format(it)) }
+                m.manufacturerHexPrefix?.let { add("hex_prefix=$it") }
+                m.manufacturerMinLength?.let { add("min_len=$it") }
+                m.namePrefix?.let { add("name_prefix=$it") }
+            }
+            if (criteria.isNotEmpty()) {
+                CfgLabel(stringResource(R.string.cfg_match))
+                criteria.forEach { CfgMono(it) }
+            }
+        }
+
+        val decodeSensors = device.sensors.filter { it.decode != null }
+        if (decodeSensors.isNotEmpty()) {
+            CfgLabel(stringResource(R.string.cfg_decode))
+            decodeSensors.forEach { s ->
+                val dec = s.decode!!
+                val scalePart = buildString {
+                    if (dec.scale != 1.0) append("×${dec.scale}")
+                    if (dec.offsetValue != 0.0) append(" ${if (dec.offsetValue >= 0) "+" else ""}${dec.offsetValue}")
+                }.trim()
+                CfgMono(
+                    stringResource(
+                        R.string.cfg_decode_line,
+                        s.key,
+                        s.sourceField.name,
+                        dec.offset,
+                        dec.length,
+                        "${dec.type.name}/${dec.endian.name}",
+                        scalePart,
+                    ),
+                )
+            }
+        }
+
+        val latest = discoveredInstances.maxByOrNull { it.lastSeenMs }
+        CfgLabel(stringResource(R.string.cfg_raw_manufacturer))
+        CfgMono(latest?.manufacturerHex ?: stringResource(R.string.cfg_raw_waiting))
+        if (device.match?.serviceDataUuid != null || latest?.serviceDataHex != null) {
+            CfgLabel(stringResource(R.string.cfg_raw_service))
+            CfgMono(latest?.serviceDataHex ?: stringResource(R.string.cfg_raw_waiting))
+        }
+    }
+}
+
+@Composable
+private fun CfgLabel(text: String) {
+    Text(text = text, color = Color.Gray, fontSize = 10.sp, fontWeight = FontWeight.SemiBold)
+}
+
+@Composable
+private fun CfgMono(text: String) {
+    Text(
+        text = text,
+        color = Color.LightGray,
+        fontSize = 11.sp,
+        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+        modifier = Modifier.padding(start = 6.dp),
+    )
 }
 
 private enum class AdvRegistrationKind { MacPerDevice, FixedMac, Shared }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -82,6 +82,15 @@
     <string name="last_seen_seconds">%1$d초 전</string>
     <string name="last_seen_minutes">%1$d분 전</string>
     <string name="last_seen_hours">%1$d시간 전</string>
+    <!-- 적용된 설정 인스펙터 -->
+    <string name="config_detail_show">적용된 설정 보기</string>
+    <string name="config_detail_hide">적용된 설정 숨기기</string>
+    <string name="cfg_match">매칭 조건</string>
+    <string name="cfg_decode">디코드</string>
+    <string name="cfg_raw_manufacturer">수신 제조사 데이터</string>
+    <string name="cfg_raw_service">수신 서비스 데이터</string>
+    <string name="cfg_raw_waiting">아직 수신된 광고 없음</string>
+    <string name="cfg_decode_line">%1$s · %2$s · off=%3$d len=%4$d %5$s %6$s</string>
     <string name="onboarding_title">시작하기</string>
     <string name="onboarding_step_ws_bridge">Home Assistant에 ws_bridge 통합 구성요소를 설치하세요 (HACS 또는 수동).</string>
     <string name="onboarding_step_token">HA 프로필 → 보안에서 장기 액세스 토큰을 발급하세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,15 @@
     <string name="last_seen_seconds">%1$d sec ago</string>
     <string name="last_seen_minutes">%1$d min ago</string>
     <string name="last_seen_hours">%1$d hr ago</string>
+    <!-- Applied-config inspector -->
+    <string name="config_detail_show">Show applied config</string>
+    <string name="config_detail_hide">Hide applied config</string>
+    <string name="cfg_match">Match</string>
+    <string name="cfg_decode">Decode</string>
+    <string name="cfg_raw_manufacturer">Received manufacturer data</string>
+    <string name="cfg_raw_service">Received service data</string>
+    <string name="cfg_raw_waiting">No advertisement received yet</string>
+    <string name="cfg_decode_line">%1$s · %2$s · off=%3$d len=%4$d %5$s %6$s</string>
     <!-- Onboarding -->
     <string name="onboarding_title">Getting Started</string>
     <string name="onboarding_step_ws_bridge">Install the ws_bridge integration in Home Assistant (HACS or manual).</string>

--- a/app/src/test/java/dev/eigger/hassble/ble/AdvertisementMatcherTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/AdvertisementMatcherTest.kt
@@ -95,6 +95,27 @@ class AdvertisementMatcherTest {
     }
 
     @Test
+    fun `live jaalee advertisement matches full config`() {
+        // 사용자가 HA에서 캡처한 실광고: manufacturer 0x4C payload + service_data F51C
+        val liveManufacturer = hexToBytes("0215ebefd08370a247c89837e7b5634df5256abaffffcc64")
+        val match = MatchConfig(
+            serviceDataUuid = "F51C",
+            manufacturerId = 0x004C,
+            manufacturerHexPrefix = "0215EBEF",
+            manufacturerMinLength = 24,
+        )
+        assertTrue(
+            AdvertisementMatcher.matches(
+                match,
+                "D2:81:A6:4A:50:DD",
+                "",
+                hasServiceUuid = { it.equals("F51C", ignoreCase = true) },
+                manufacturerPayload = { if (it == 0x004C) liveManufacturer else null },
+            ),
+        )
+    }
+
+    @Test
     fun `single manufacturer criterion`() {
         val match = MatchConfig(manufacturerId = 0x035D)
         assertTrue(

--- a/app/src/test/java/dev/eigger/hassble/decode/JaaleeDecodeTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/JaaleeDecodeTest.kt
@@ -50,4 +50,35 @@ class JaaleeDecodeTest {
         assertEquals(57.2, humidity, 1.0)
         assertEquals(77.0, (battery as Number).toDouble(), 0.01)
     }
+
+    /** 사용자가 HA에서 캡처한 실광고 manufacturer payload (company ID 0x4C 제외). */
+    private val liveManufacturerHex = "0215ebefd08370a247c89837e7b5634df5256abaffffcc64"
+
+    @Test
+    fun `live advertisement decodes temperature humidity battery`() {
+        val bytes = Decoder.hexToBytes(liveManufacturerHex)!!
+        assertEquals(24, bytes.size)
+        // device 시그니처: bytes[16..17] == 0xF525
+        assertEquals(0xF525, ((bytes[16].toInt() and 0xFF) shl 8) or (bytes[17].toInt() and 0xFF))
+
+        val temp = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(offset = 18, length = 2, type = DataType.uint16, endian = Endian.big, scale = 0.002670288, offsetValue = -45.0),
+        ) as Double
+        val humidity = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(offset = 20, length = 2, type = DataType.uint16, endian = Endian.big, scale = 0.001524504),
+        ) as Double
+        val battery = Decoder.decodeStructured(
+            bytes,
+            DecodeConfig(offset = 23, length = 1, type = DataType.uint8),
+        )
+
+        // 0x6ABA=27322 → 27322*0.002670288-45 ≈ 27.95°C
+        assertEquals(27.95, temp, 0.1)
+        // 0xFFFF=65535 → 65535*0.001524504 ≈ 99.9%
+        assertEquals(99.9, humidity, 0.2)
+        // 0x64 = 100%
+        assertEquals(100.0, (battery as Number).toDouble(), 0.01)
+    }
 }


### PR DESCRIPTION
…sing verification.

- Fix status bar clip: apply statusBarsPadding to root Column
- Fix sensor text overlap: wrap device card info in Column instead of Box
- Add config inspector: collapsible section showing match criteria, decode params, raw hex
- Expose manufacturerHex/serviceDataHex in DiscoveredAdvInstance for inspector UI
- Add Jaalee live advertisement decode test and matcher test using HA-captured data