### PR TITLE
Bump version to 0.1.7: initial null states, BLE diagnostics, Jaalee e…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
-        versionName = "0.1.6"
+        versionCode = 8
+        versionName = "0.1.7"
     }
 
     buildTypes {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -94,6 +94,7 @@ class BleRuntime(
 
     private fun declareEntitiesForInstance(d: DeviceConfig, instanceId: String, deviceDisplayName: String) {
         val ref = DeviceRef(instanceId, deviceDisplayName)
+        val newSensorUids = mutableListOf<String>()
         for (s in d.sensors) {
             if (!isEnabled(d.id, s.key)) continue
             val entityUid = uid(instanceId, s.key)
@@ -105,7 +106,9 @@ class BleRuntime(
                 stateClass = s.stateClass, icon = s.icon,
                 entityCategory = s.entityCategory,
             ))
+            newSensorUids += entityUid
         }
+        ws.sendInitialStates(newSensorUids)
         for (c in d.controls) {
             val entityUid = uid(instanceId, c.key)
             controls[entityUid] = d to c

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -62,6 +62,12 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                 val manufacturerData = scanRecord?.manufacturerSpecificData
                 val rawBytes = scanRecord?.bytes
 
+                if ((manufacturerData != null && manufacturerData.size() > 0) || serviceData.isNotEmpty()) {
+                    val mfrIds = (0 until (manufacturerData?.size() ?: 0)).map { manufacturerData!!.keyAt(it) }
+                    val svcUuids = serviceData.keys.map { it.uuid.toString().takeLast(8) }
+                    Log.d(TAG, "ADV addr=$deviceAddress name='$deviceName' mfr=$mfrIds svc=$svcUuids")
+                }
+
                 for (d in devices) {
                     if (d.source != Source.advertisement) continue
                     val match = d.match ?: continue
@@ -82,6 +88,9 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                             },
                         )
                     ) {
+                        if (match.manufacturerId != null || match.serviceDataUuid != null) {
+                            Log.d(TAG, "  NO MATCH profile=${d.id} mfrId=${match.manufacturerId} svcUuid=${match.serviceDataUuid}")
+                        }
                         continue
                     }
 
@@ -99,7 +108,11 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                         SourceField.manufacturer_data -> manufacturerHex
                         SourceField.raw -> fullScanHex
                     }
-                    if (primaryHex.isNullOrBlank()) continue
+                    if (primaryHex.isNullOrBlank()) {
+                        Log.d(TAG, "  MATCHED ${d.id} addr=$deviceAddress but $primaryField is null (mfr=$manufacturerHex)")
+                        continue
+                    }
+                    Log.i(TAG, "MATCHED ${d.id} addr=$deviceAddress mfr=${manufacturerHex?.take(16)} svc=${serviceDataHex?.take(16)}")
 
                     emit(
                         RawReading(

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -114,6 +115,21 @@ class HaWsClient(
                         is Boolean -> put("value", v)
                         else -> put("value", v.toString())
                     }
+                })
+            })
+            put("ts", System.currentTimeMillis() / 1000)
+        }.toString())
+    }
+
+    fun sendInitialStates(uids: List<String>) {
+        if (uids.isEmpty()) return
+        enqueueOrSend(buildJsonObject {
+            put("id", idGen.getAndIncrement())
+            put("type", "$WS_DOMAIN/state")
+            put("states", buildJsonArray {
+                for (uid in uids) add(buildJsonObject {
+                    put("unique_id", uid)
+                    put("value", JsonNull)
                 })
             })
             put("ts", System.currentTimeMillis() / 1000)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,3 +15,49 @@ devices:
           type: int16
           endian: little
           scale: 0.1
+
+  # Jaalee JHT (온도/습도/배터리) — iBeacon 형식 (Apple 0x004C)
+  # source_field: manufacturer_data 필수 — 오프셋이 24바이트 manufacturer payload 기준
+  # manufacturer_id: 76 (= 0x004C, Apple) — kaml은 hex 리터럴 불안정, decimal 사용
+  - id: jaalee_jht
+    name: "Jaalee JHT"
+    source: advertisement
+    instance_mode: mac
+    match:
+      service_data_uuid: "F51C"
+      manufacturer_id: 76        # Apple Inc. (0x004C)
+      manufacturer_min_length: 24
+    sensors:
+      - key: temperature
+        device_class: temperature
+        unit: "°C"
+        state_class: measurement
+        accuracy_decimals: 1
+        source_field: manufacturer_data
+        decode:
+          offset: 18
+          length: 2
+          type: int16
+          endian: big
+          scale: 0.1
+      - key: humidity
+        device_class: humidity
+        unit: "%"
+        state_class: measurement
+        accuracy_decimals: 1
+        source_field: manufacturer_data
+        decode:
+          offset: 20
+          length: 2
+          type: uint16
+          endian: big
+          scale: 0.1
+      - key: battery
+        device_class: battery
+        unit: "%"
+        state_class: measurement
+        source_field: manufacturer_data
+        decode:
+          offset: 23
+          length: 1
+          type: uint8


### PR DESCRIPTION
…xample

- versionCode 7→8, versionName 0.1.6→0.1.7
- HaWsClient: add sendInitialStates() — sends null state for each entity immediately after declaration so sensors appear in HA on connect
- BleRuntime: call sendInitialStates() after declaring sensor entities
- NordicBleSources: add ADV/NO MATCH/MATCHED diagnostic logging for BLE parsing troubleshooting (Log.d/Log.i with tag HassBleSources)
- config.example.yaml: add Jaalee JHT example with notes on source_field and decimal manufacturer_id