### PR TITLE
feat: v0.1.13 - BLE scan mode config, device disable/enable, HA auto-…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 13
-        versionName = "0.1.12"
+        versionCode = 14
+        versionName = "0.1.13"
     }
 
     buildTypes {

--- a/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
@@ -1,5 +1,6 @@
 package dev.eigger.hassble.ble
 
+import dev.eigger.hassble.config.BleScanModeOption
 import dev.eigger.hassble.config.DeviceConfig
 import kotlinx.coroutines.flow.Flow
 
@@ -21,7 +22,7 @@ data class RawReading(
 
 /** 경로 A: 광고 passive scan. match를 ScanFilter로 변환. */
 interface AdvertisementScanner {
-    fun scan(devices: List<DeviceConfig>): Flow<RawReading>
+    fun scan(devices: List<DeviceConfig>, scanMode: BleScanModeOption = BleScanModeOption.LOW_LATENCY): Flow<RawReading>
     fun stop()
 }
 

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -1,6 +1,7 @@
 package dev.eigger.hassble.ble
 
 import dev.eigger.hassble.config.AdvertisementInstanceMode
+import dev.eigger.hassble.config.BleScanModeOption
 import dev.eigger.hassble.config.ControlConfig
 import dev.eigger.hassble.config.DeviceConfig
 import dev.eigger.hassble.config.GatewayConfig
@@ -52,6 +53,8 @@ class BleRuntime(
     private lateinit var config: GatewayConfig
     private lateinit var enabled: Set<String>                 // "deviceId/sensorKey"
     private var boundDevices: Map<String, String> = emptyMap() // Map of deviceId -> MAC
+    private var scanMode: BleScanModeOption = BleScanModeOption.LOW_LATENCY
+    private var disabledIds: Set<String> = emptySet()
     private val devices = mutableMapOf<String, DeviceConfig>()
     private val filters = mutableMapOf<String, ValueFilter>()  // uniqueId → filter
     private val obdIndex = mutableMapOf<String, Map<Pair<String, String>, SensorConfig>>()
@@ -73,10 +76,12 @@ class BleRuntime(
     }
 
     /** 설정 적용 + 사용자가 켠 센서로 엔티티 선언 + BLE 기동. */
-    fun apply(config: GatewayConfig, enabledKeys: Set<String>, boundDevices: Map<String, String>) {
+    fun apply(config: GatewayConfig, enabledKeys: Set<String>, boundDevices: Map<String, String>, scanMode: BleScanModeOption = BleScanModeOption.LOW_LATENCY, disabledIds: Set<String> = emptySet()) {
         this.config = config
         this.enabled = enabledKeys
         this.boundDevices = boundDevices
+        this.scanMode = scanMode
+        this.disabledIds = disabledIds
         jobs.forEach { it.cancel() }; jobs.clear(); scanner.stop()
         devices.clear(); filters.clear(); obdIndex.clear(); controls.clear()
         declaredAdvInstances.clear()
@@ -97,6 +102,7 @@ class BleRuntime(
     }
 
     private fun declareAndPrepare(d: DeviceConfig) {
+        if (d.id in disabledIds) return
         // match.mac 없는 광고 프로필은 첫 패킷 수신 시 MAC별로 동적 선언
         if (isDynamicAdvertisement(d)) return
         declareEntitiesForInstance(d, d.id, d.name)
@@ -143,8 +149,8 @@ class BleRuntime(
     }
 
     private fun startSources() {
-        val adv = config.devices.filter { it.source == Source.advertisement }
-        if (adv.isNotEmpty()) jobs += scanner.scan(adv).onEach(::onReading).launchIn(scope)
+        val adv = config.devices.filter { it.source == Source.advertisement && it.id !in disabledIds }
+        if (adv.isNotEmpty()) jobs += scanner.scan(adv, scanMode).onEach(::onReading).launchIn(scope)
         for (d in config.devices) {
             val resolved = resolveDeviceMac(d)
             when (resolved.source) {
@@ -182,6 +188,7 @@ class BleRuntime(
     // ── BLE raw → 디코딩 → 필터 → push ──────────────────────────────────────
     private fun onReading(r: RawReading) {
         val d = devices[r.deviceId] ?: return
+        if (d.id in disabledIds) return
         val logType = when (d.source) {
             Source.advertisement -> LogType.ADV
             Source.obd, Source.gatt_notify -> LogType.NOTIF
@@ -384,6 +391,18 @@ class BleRuntime(
     }
 
     private fun normalizeMac(mac: String) = mac.replace(":", "").replace("-", "").uppercase()
+
+    fun entityUniqueIdsForDevice(deviceId: String): List<String> {
+        val d = devices[deviceId] ?: return emptyList()
+        val instanceIds = if (isDynamicAdvertisement(d)) {
+            discoveredAdvInstances.values.filter { it.profileId == deviceId }.map { it.instanceId } + listOf(deviceId)
+        } else {
+            listOf(d.id)
+        }
+        return instanceIds.flatMap { instanceId ->
+            d.sensors.map { uid(instanceId, it.key) } + d.controls.map { uid(instanceId, it.key) }
+        }.distinct()
+    }
 
     private fun isEnabled(deviceId: String, key: String) = "$deviceId/$key" in enabled
     private fun uid(deviceId: String, key: String) = "${deviceId}_$key"

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -31,6 +31,9 @@ import no.nordicsemi.android.kotlin.ble.client.main.service.ClientBleGattCharact
 import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
 import no.nordicsemi.android.kotlin.ble.scanner.BleScanner
+import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanMode
+import no.nordicsemi.android.kotlin.ble.core.scanner.BleScannerSettings
+import dev.eigger.hassble.config.BleScanModeOption
 import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
 import java.util.UUID
@@ -45,7 +48,7 @@ private const val TAG = "HassBleSources"
 class NordicAdvertisementScanner(private val context: Context) : AdvertisementScanner {
     private var scanJob: Job? = null
 
-    override fun scan(devices: List<DeviceConfig>): Flow<RawReading> = flow {
+    override fun scan(devices: List<DeviceConfig>, scanMode: BleScanModeOption): Flow<RawReading> = flow {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
             Log.e(TAG, "BLUETOOTH_SCAN permission not granted")
             LiveEventLogger.log(LogType.LINK, "BLE scan failed: BLUETOOTH_SCAN permission not granted")
@@ -56,8 +59,19 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
         Log.d(TAG, "Starting Nordic BLE scan for ${devices.size} advertisement profiles")
         LiveEventLogger.log(LogType.LINK, "Starting Nordic BLE scan for ${devices.size} profiles...")
 
+        val nativeScanMode = when (scanMode) {
+            BleScanModeOption.LOW_POWER -> BleScanMode.SCAN_MODE_LOW_POWER
+            BleScanModeOption.BALANCED -> BleScanMode.SCAN_MODE_BALANCED
+            BleScanModeOption.LOW_LATENCY -> BleScanMode.SCAN_MODE_LOW_LATENCY
+        }
+        val scanSettings = BleScannerSettings(
+            scanMode = nativeScanMode,
+            legacy = true,
+        )
+        LiveEventLogger.log(LogType.LINK, "BLE scan mode: ${scanMode.label}")
+
         try {
-            scanner.scan().collect { result ->
+            scanner.scan(settings = scanSettings).collect { result ->
                 val deviceName = result.device.name ?: ""
                 val deviceAddress = result.device.address
                 val scanRecord = result.data?.scanRecord

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -130,6 +130,12 @@ data class ControlConfig(
 
 enum class ControlType { switch, number, select, button }
 
+enum class BleScanModeOption(val label: String) {
+    LOW_POWER("Low Power"),
+    BALANCED("Balanced"),
+    LOW_LATENCY("Low Latency"),
+}
+
 @Serializable
 data class PublishRule(
     @SerialName("on_change_only") val onChangeOnly: Boolean = true,

--- a/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.builtins.MapSerializer
@@ -30,6 +31,9 @@ class HassSettingsRepository(private val context: Context) {
         private val KEY_ENABLED_SENSORS_INITIALIZED = booleanPreferencesKey("enabled_sensors_initialized")
         private val KEY_ALL_KNOWN_SENSORS = stringPreferencesKey("all_known_sensors")
         private val KEY_ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
+        private val KEY_SCAN_MODE = stringPreferencesKey("ble_scan_mode")
+        private val KEY_DISABLED_DEVICES = stringPreferencesKey("disabled_devices")
+        private val KEY_KNOWN_DEVICE_IDS = stringPreferencesKey("known_device_ids")
     }
 
     val haUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -72,6 +76,51 @@ class HassSettingsRepository(private val context: Context) {
 
     val onboardingComplete: Flow<Boolean> = context.dataStore.data.map { prefs ->
         prefs[KEY_ONBOARDING_COMPLETE] ?: false
+    }
+
+    val scanMode: Flow<BleScanModeOption> = context.dataStore.data.map { prefs ->
+        runCatching { BleScanModeOption.valueOf(prefs[KEY_SCAN_MODE] ?: "") }
+            .getOrDefault(BleScanModeOption.LOW_LATENCY)
+    }
+
+    val disabledDevices: Flow<Set<String>> = context.dataStore.data.map { prefs ->
+        runCatching {
+            json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_DISABLED_DEVICES] ?: "[]").toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    suspend fun setDeviceDisabled(deviceId: String, disabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            val current = runCatching {
+                json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_DISABLED_DEVICES] ?: "[]").toMutableSet()
+            }.getOrDefault(mutableSetOf())
+            if (disabled) current.add(deviceId) else current.remove(deviceId)
+            prefs[KEY_DISABLED_DEVICES] = json.encodeToString(ListSerializer(String.serializer()), current.sorted())
+        }
+    }
+
+    suspend fun clearDisabledDevices() {
+        context.dataStore.edit { prefs -> prefs.remove(KEY_DISABLED_DEVICES) }
+    }
+
+    suspend fun getRemovedDeviceIds(newConfigIds: Set<String>): Set<String> {
+        val prefs = context.dataStore.data.first()
+        val known = runCatching {
+            json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_KNOWN_DEVICE_IDS] ?: "[]").toSet()
+        }.getOrDefault(emptySet())
+        return known - newConfigIds
+    }
+
+    suspend fun updateKnownDeviceIds(ids: Set<String>) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_KNOWN_DEVICE_IDS] = json.encodeToString(ListSerializer(String.serializer()), ids.sorted())
+        }
+    }
+
+    suspend fun saveScanMode(mode: BleScanModeOption) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_SCAN_MODE] = mode.name
+        }
     }
 
     suspend fun setOnboardingComplete(complete: Boolean) {

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -1,5 +1,6 @@
 package dev.eigger.hassble.net
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -13,11 +14,15 @@ import kotlinx.coroutines.launch
 import dev.eigger.hassble.BuildConfig
 import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -75,6 +80,7 @@ class HaWsClient(
     private var isClosedManually = false
     private var authFailed = false
     private var reconnectDelayMs = 2000L
+    private val pendingRequests = java.util.concurrent.ConcurrentHashMap<Int, CompletableDeferred<JsonObject>>()
 
     fun connect() {
         if (_connectionState.value != ConnectionState.Disconnected) return
@@ -148,6 +154,42 @@ class HaWsClient(
             put("device_id", deviceId)
             put("online", online)
         }.toString())
+    }
+
+    suspend fun removeEntitiesByDeviceIdPrefix(deviceId: String) {
+        if (_connectionState.value != ConnectionState.Connected) return
+        val response = sendRequest("config/entity_registry/list") ?: return
+        val entities = runCatching { response["result"]?.jsonArray }.getOrNull() ?: return
+        val prefix = "${deviceId}_"
+        for (entity in entities) {
+            val obj = runCatching { entity.jsonObject }.getOrNull() ?: continue
+            val uid = obj["unique_id"]?.jsonPrimitive?.contentOrNull ?: continue
+            if (!uid.startsWith(prefix)) continue
+            val entityId = obj["entity_id"]?.jsonPrimitive?.contentOrNull ?: continue
+            sendRequest("config/entity_registry/remove") { put("entity_id", entityId) }
+        }
+    }
+
+    suspend fun removeEntitiesByUniqueIds(uniqueIds: List<String>) {
+        if (uniqueIds.isEmpty() || _connectionState.value != ConnectionState.Connected) return
+        val uniqueIdSet = uniqueIds.toSet()
+        val response = sendRequest("config/entity_registry/list") ?: return
+        val entities = runCatching { response["result"]?.jsonArray }.getOrNull() ?: return
+        for (entity in entities) {
+            val obj = runCatching { entity.jsonObject }.getOrNull() ?: continue
+            val uid = obj["unique_id"]?.jsonPrimitive?.contentOrNull ?: continue
+            if (uid !in uniqueIdSet) continue
+            val entityId = obj["entity_id"]?.jsonPrimitive?.contentOrNull ?: continue
+            sendRequest("config/entity_registry/remove") { put("entity_id", entityId) }
+        }
+    }
+
+    private suspend fun sendRequest(type: String, build: JsonObjectBuilder.() -> Unit = {}): JsonObject? {
+        val id = idGen.getAndIncrement()
+        val deferred = CompletableDeferred<JsonObject>()
+        pendingRequests[id] = deferred
+        enqueueOrSend(buildJsonObject { put("id", id); put("type", type); build() }.toString())
+        return withTimeoutOrNull(10_000) { deferred.await() }
     }
 
     private fun enqueueOrSend(text: String) {
@@ -234,8 +276,9 @@ class HaWsClient(
                 }
                 "result" -> {
                     val id = msg["id"]?.jsonPrimitive?.content?.toIntOrNull()
-                    if (id != null && id == connectMessageId) {
-                        onConnectResult()
+                    if (id != null) {
+                        pendingRequests.remove(id)?.complete(msg)
+                        if (id == connectMessageId) onConnectResult()
                     }
                 }
                 "event" -> msg["event"]?.let { _events.tryEmit(it.jsonObject) }

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -84,6 +84,23 @@ class BleGatewayService : Service() {
             return START_STICKY
         }
 
+        if (intent?.action == ACTION_DISABLE_DEVICE) {
+            val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            scope.launch {
+                val repository = HassSettingsRepository(this@BleGatewayService)
+                repository.setDeviceDisabled(deviceId, true)
+                val uniqueIds = runtime?.entityUniqueIdsForDevice(deviceId) ?: emptyList()
+                ws?.removeEntitiesByUniqueIds(uniqueIds)
+            }
+            return START_STICKY
+        }
+
+        if (intent?.action == ACTION_ENABLE_DEVICE) {
+            val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            scope.launch { HassSettingsRepository(this@BleGatewayService).setDeviceDisabled(deviceId, false) }
+            return START_STICKY
+        }
+
         val haUrl = intent?.getStringExtra(EXTRA_HA_URL) ?: return START_NOT_STICKY
         val token = intent.getStringExtra(EXTRA_TOKEN) ?: return START_NOT_STICKY
         currentGitUrl = intent.getStringExtra(EXTRA_GIT_URL) ?: return START_NOT_STICKY
@@ -134,6 +151,7 @@ class BleGatewayService : Service() {
         _usingCachedConfig.value = false
 
         configJob = scope.launch {
+            HassSettingsRepository(this@BleGatewayService).clearDisabledDevices()
             val presets = ObdPresetStore.fromYaml(
                 assets.open("obd_presets.yaml").bufferedReader().readText(),
             )
@@ -156,6 +174,14 @@ class BleGatewayService : Service() {
             currentConfig = config
             val defaultEnabled = defaultEnabled(config)
             val repository = HassSettingsRepository(applicationContext)
+
+            val newConfigIds = config.devices.map { it.id }.toSet()
+            val removedIds = repository.getRemovedDeviceIds(newConfigIds)
+            if (removedIds.isNotEmpty()) {
+                LiveEventLogger.log(LogType.LINK, "Config 변경: 삭제된 기기 HA 정리 중 (${removedIds.joinToString()})")
+                removedIds.forEach { deviceId -> ws?.removeEntitiesByDeviceIdPrefix(deviceId) }
+            }
+            repository.updateKnownDeviceIds(newConfigIds)
 
             if (runtime == null) {
                 val onLinkStatus: (DeviceLinkStatus) -> Unit = { status ->
@@ -192,11 +218,19 @@ class BleGatewayService : Service() {
                     repository.boundDevices,
                     repository.enabledSensors,
                     repository.enabledSensorsInitialized,
-                ) { boundMap, enabledSensors, initialized ->
-                    val effectiveEnabled = if (!initialized) defaultEnabled else enabledSensors
-                    boundMap to effectiveEnabled
-                }.collect { (boundMap, effectiveEnabled) ->
-                    runtime?.apply(config, effectiveEnabled, boundMap)
+                    repository.scanMode,
+                    repository.disabledDevices,
+                ) { args ->
+                    val boundMap = args[0] as Map<*, *>
+                    val enabledSensors = args[1] as Set<*>
+                    val initialized = args[2] as Boolean
+                    val scanMode = args[3] as dev.eigger.hassble.config.BleScanModeOption
+                    val disabledDevices = args[4] as Set<*>
+                    val effectiveEnabled = if (!initialized) defaultEnabled else enabledSensors.filterIsInstance<String>().toSet()
+                    Pair(Triple(boundMap.entries.associate { it.key.toString() to it.value.toString() }, effectiveEnabled, scanMode), disabledDevices.filterIsInstance<String>().toSet())
+                }.collect { (triple, disabledDevices) ->
+                    val (boundMap, effectiveEnabled, scanMode) = triple
+                    runtime?.apply(config, effectiveEnabled, boundMap, scanMode, disabledDevices)
                 }
             }
             updateNotification()
@@ -310,7 +344,10 @@ class BleGatewayService : Service() {
         const val EXTRA_TOKEN = "token"
         const val EXTRA_GIT_URL = "git_url"
         const val EXTRA_GIT_TOKEN = "git_token"
+        private const val EXTRA_DEVICE_ID = "device_id"
         private const val ACTION_RELOAD_CONFIG = "dev.eigger.hassble.RELOAD_CONFIG"
+        private const val ACTION_DISABLE_DEVICE = "dev.eigger.hassble.DISABLE_DEVICE"
+        private const val ACTION_ENABLE_DEVICE = "dev.eigger.hassble.ENABLE_DEVICE"
 
         private val _serviceConnectionState = MutableStateFlow(ConnectionState.Disconnected)
         val serviceConnectionState: StateFlow<ConnectionState> = _serviceConnectionState.asStateFlow()
@@ -357,6 +394,16 @@ class BleGatewayService : Service() {
 
         fun stop(context: Context) {
             context.stopService(Intent(context, BleGatewayService::class.java))
+        }
+
+        fun disableDevice(context: Context, deviceId: String) {
+            context.startService(Intent(context, BleGatewayService::class.java)
+                .setAction(ACTION_DISABLE_DEVICE).putExtra(EXTRA_DEVICE_ID, deviceId))
+        }
+
+        fun enableDevice(context: Context, deviceId: String) {
+            context.startService(Intent(context, BleGatewayService::class.java)
+                .setAction(ACTION_ENABLE_DEVICE).putExtra(EXTRA_DEVICE_ID, deviceId))
         }
     }
 }

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -169,6 +169,7 @@ private fun HomeScreen() {
     val enabledSensors by repository.enabledSensors.collectAsState(initial = emptySet())
     val enabledSensorsInitialized by repository.enabledSensorsInitialized.collectAsState(initial = false)
     val startOnBoot by repository.startOnBoot.collectAsState(initial = true)
+    val scanMode by repository.scanMode.collectAsState(initial = dev.eigger.hassble.config.BleScanModeOption.LOW_LATENCY)
     val onboardingComplete by repository.onboardingComplete.collectAsState(initial = false)
 
     val powerManager = remember { context.getSystemService(Context.POWER_SERVICE) as PowerManager }
@@ -222,6 +223,7 @@ private fun HomeScreen() {
     val serviceError by BleGatewayService.serviceError.collectAsState()
     val usingCachedConfigService by BleGatewayService.usingCachedConfig.collectAsState()
     val deviceLinkStatuses by BleGatewayService.deviceLinkStatuses.collectAsState()
+    val disabledDeviceIds by repository.disabledDevices.collectAsState(initial = emptySet())
     val discoveredAdv by BleGatewayService.discoveredAdvInstances.collectAsState()
     val sensorLastValues by BleGatewayService.sensorLastValues.collectAsState()
 
@@ -373,6 +375,8 @@ private fun HomeScreen() {
                     onGitTokenChange = { gitTokenInput = it },
                     startOnBoot = startOnBoot,
                     onStartOnBootChange = { scope.launch { repository.saveStartOnBoot(it) } },
+                    scanMode = scanMode,
+                    onScanModeChange = { scope.launch { repository.saveScanMode(it) } },
                     isBatteryIgnored = isBatteryIgnored,
                     onShowOnboarding = { showOnboarding = true },
                     onStartGateway = {
@@ -395,6 +399,7 @@ private fun HomeScreen() {
                     loadedConfig = loadedConfig,
                     boundDevices = boundDevices,
                     enabledSensors = effectiveEnabledSensors,
+                    disabledDeviceIds = disabledDeviceIds,
                     discoveredAdv = discoveredAdv,
                     sensorLastValues = sensorLastValues,
                     deviceLinkStatuses = deviceLinkStatuses,
@@ -407,6 +412,8 @@ private fun HomeScreen() {
                     onSensorsBulkToggle = { keys, enabled ->
                         scope.launch { repository.setSensorsEnabled(keys, enabled) }
                     },
+                    onDisableDevice = { deviceId -> BleGatewayService.disableDevice(context, deviceId) },
+                    onEnableDevice = { deviceId -> BleGatewayService.enableDevice(context, deviceId) },
                 )
                 2 -> LogsTabContent()
             }
@@ -487,6 +494,8 @@ private fun GatewayTabContent(
     onGitTokenChange: (String) -> Unit,
     startOnBoot: Boolean,
     onStartOnBootChange: (Boolean) -> Unit,
+    scanMode: dev.eigger.hassble.config.BleScanModeOption,
+    onScanModeChange: (dev.eigger.hassble.config.BleScanModeOption) -> Unit,
     isBatteryIgnored: Boolean,
     onShowOnboarding: () -> Unit,
     onStartGateway: () -> Unit,
@@ -634,6 +643,37 @@ private fun GatewayTabContent(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(text = "BLE 스캔 모드", fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = Color.White)
+                    Text(
+                        text = when (scanMode) {
+                            dev.eigger.hassble.config.BleScanModeOption.LOW_POWER -> "절전 (광고 수신 불안정)"
+                            dev.eigger.hassble.config.BleScanModeOption.BALANCED -> "균형"
+                            dev.eigger.hassble.config.BleScanModeOption.LOW_LATENCY -> "고성능 (권장)"
+                        },
+                        fontSize = 11.sp, color = Color.Gray,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        dev.eigger.hassble.config.BleScanModeOption.entries.forEach { mode ->
+                            val selected = scanMode == mode
+                            Button(
+                                onClick = { onScanModeChange(mode) },
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = if (selected) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.08f),
+                                    contentColor = if (selected) Color.Black else Color.White,
+                                ),
+                                shape = RoundedCornerShape(8.dp),
+                                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+                            ) {
+                                Text(mode.label, fontSize = 11.sp, fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal)
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
                 Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(text = stringResource(R.string.battery_opt_status), fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = Color.White)
@@ -707,6 +747,7 @@ private fun SensorsTabContent(
     loadedConfig: GatewayConfig?,
     boundDevices: Map<String, String>,
     enabledSensors: Set<String>,
+    disabledDeviceIds: Set<String>,
     discoveredAdv: List<DiscoveredAdvInstance>,
     sensorLastValues: List<SensorLastValue>,
     deviceLinkStatuses: List<DeviceLinkStatus>,
@@ -715,6 +756,8 @@ private fun SensorsTabContent(
     onUnbindClick: (String) -> Unit,
     onSensorToggle: (String, Boolean) -> Unit,
     onSensorsBulkToggle: (Set<String>, Boolean) -> Unit,
+    onDisableDevice: (String) -> Unit,
+    onEnableDevice: (String) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -820,6 +863,7 @@ private fun SensorsTabContent(
                     boundMac = boundDevices[device.id],
                     enabledSensors = enabledSensors,
                     isRunning = isRunning,
+                    isDisabled = device.id in disabledDeviceIds,
                     discoveredInstances = discoveredAdv.filter { it.profileId == device.id },
                     sensorLastValues = sensorLastValues.filter { it.profileId == device.id },
                     linkStatus = deviceLinkStatuses.firstOrNull { it.profileId == device.id },
@@ -827,6 +871,8 @@ private fun SensorsTabContent(
                     onSensorsBulkToggle = onSensorsBulkToggle,
                     onBindClick = { onBindClick(device) },
                     onUnbindClick = { onUnbindClick(device.id) },
+                    onDisable = { onDisableDevice(device.id) },
+                    onEnable = { onEnableDevice(device.id) },
                 )
             }
         }
@@ -866,6 +912,7 @@ private fun DeviceConfigCard(
     boundMac: String?,
     enabledSensors: Set<String>,
     isRunning: Boolean,
+    isDisabled: Boolean,
     discoveredInstances: List<DiscoveredAdvInstance>,
     sensorLastValues: List<SensorLastValue>,
     linkStatus: DeviceLinkStatus?,
@@ -873,6 +920,8 @@ private fun DeviceConfigCard(
     onSensorsBulkToggle: (Set<String>, Boolean) -> Unit,
     onBindClick: () -> Unit,
     onUnbindClick: () -> Unit,
+    onDisable: () -> Unit,
+    onEnable: () -> Unit,
 ) {
     val deviceSensorKeys = remember(device.id, device.sensors) {
         device.sensors.map { "${device.id}/${it.key}" }
@@ -885,7 +934,10 @@ private fun DeviceConfigCard(
             .fillMaxWidth()
             .animateContentSize(),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isDisabled) MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+            else MaterialTheme.colorScheme.surface
+        ),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -895,7 +947,24 @@ private fun DeviceConfigCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text(text = device.name, fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.White)
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = device.name,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp,
+                            color = if (isDisabled) Color.Gray else Color.White,
+                        )
+                        if (isDisabled) {
+                            Text(
+                                text = "비활성화됨",
+                                fontSize = 10.sp,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier
+                                    .background(MaterialTheme.colorScheme.error.copy(alpha = 0.15f), RoundedCornerShape(4.dp))
+                                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                            )
+                        }
+                    }
                     Text(text = "ID: ${device.id}", fontSize = 12.sp, color = Color.Gray)
                     if (device.sensors.isNotEmpty()) {
                         Text(
@@ -1222,6 +1291,37 @@ private fun DeviceConfigCard(
                         device = device,
                         discoveredInstances = discoveredInstances,
                     )
+
+                    if (isRunning) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                            if (isDisabled) {
+                                Button(
+                                    onClick = onEnable,
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                                        contentColor = MaterialTheme.colorScheme.primary,
+                                    ),
+                                    shape = RoundedCornerShape(8.dp),
+                                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+                                ) {
+                                    Text("활성화", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                                }
+                            } else {
+                                Button(
+                                    onClick = onDisable,
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.12f),
+                                        contentColor = MaterialTheme.colorScheme.error,
+                                    ),
+                                    shape = RoundedCornerShape(8.dp),
+                                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+                                ) {
+                                    Text("비활성화 (HA 삭제)", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
…cleanup

- Add configurable BLE scan mode (LOW_LATENCY default) with UI in Gateway tab
- Set legacy=true to detect non-connectable devices (iBeacon/Jaalee)
- Add device disable/enable from device card; removes HA entities on disable
- Clear disabled state on config reload (devices restored from config)
- Auto-remove HA entities for devices removed from config on reload