### PR TITLE
fix: strip whitespace from base64 keystore, use storepass for keypass…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Decode keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${{ github.workspace }}/hassble-release.jks"
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | tr -d ' \r\n' | base64 -d > "${{ github.workspace }}/hassble-release.jks"
 
       - name: Build release APK
         run: ./gradlew assembleRelease
@@ -41,7 +41,7 @@ jobs:
           KEYSTORE_FILE: ${{ github.workspace }}/hassble-release.jks
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASS: ${{ secrets.KEY_PASS }}
+          KEY_PASS: ${{ secrets.KEYSTORE_PASS }}
 
       - name: Upload APK to Release
         run: |


### PR DESCRIPTION
… (PKCS12)

PKCS12 keystore ignores separate keypass — use KEYSTORE_PASS for both. tr -d removes any line breaks introduced during copy-paste on Windows.