### PR TITLE
feat: v0.1.16 - auto_connect UI toggle, link state sensor, short UUID…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 15
-        versionName = "0.1.15"
+        versionCode = 16
+        versionName = "0.1.16"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -55,6 +55,7 @@ class BleRuntime(
     private var boundDevices: Map<String, String> = emptyMap() // Map of deviceId -> MAC
     private var scanMode: BleScanModeOption = BleScanModeOption.BALANCED
     private var disabledIds: Set<String> = emptySet()
+    private var autoConnectDisabledIds: Set<String> = emptySet()
     private val devices = mutableMapOf<String, DeviceConfig>()
     private val filters = mutableMapOf<String, ValueFilter>()  // uniqueId → filter
     private val obdIndex = mutableMapOf<String, Map<Pair<String, String>, SensorConfig>>()
@@ -76,12 +77,13 @@ class BleRuntime(
     }
 
     /** 설정 적용 + 사용자가 켠 센서로 엔티티 선언 + BLE 기동. */
-    fun apply(config: GatewayConfig, enabledKeys: Set<String>, boundDevices: Map<String, String>, scanMode: BleScanModeOption = BleScanModeOption.BALANCED, disabledIds: Set<String> = emptySet()) {
+    fun apply(config: GatewayConfig, enabledKeys: Set<String>, boundDevices: Map<String, String>, scanMode: BleScanModeOption = BleScanModeOption.BALANCED, disabledIds: Set<String> = emptySet(), autoConnectDisabledIds: Set<String> = emptySet()) {
         this.config = config
         this.enabled = enabledKeys
         this.boundDevices = boundDevices
         this.scanMode = scanMode
         this.disabledIds = disabledIds
+        this.autoConnectDisabledIds = autoConnectDisabledIds
         jobs.forEach { it.cancel() }; jobs.clear(); scanner.stop()
         devices.clear(); filters.clear(); obdIndex.clear(); controls.clear()
         declaredAdvInstances.clear()
@@ -156,13 +158,13 @@ class BleRuntime(
             when (resolved.source) {
                 Source.gatt_notify -> {
                     val mac = resolved.gatt?.mac
-                    if (!mac.isNullOrBlank()) {
+                    if (!mac.isNullOrBlank() && d.id !in autoConnectDisabledIds) {
                         jobs += gatt.connect(resolved).onEach(::onReading).launchIn(scope)
                     }
                 }
                 Source.obd -> {
                     val mac = resolved.obd?.mac
-                    if (!mac.isNullOrBlank()) {
+                    if (!mac.isNullOrBlank() && d.id !in autoConnectDisabledIds) {
                         val keys = resolved.sensors.map { it.key }.filter { isEnabled(resolved.id, it) }.toSet()
                         jobs += obd.connect(resolved, keys).onEach(::onReading).launchIn(scope)
                     }

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -38,6 +38,15 @@ import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
 import java.util.UUID
 
+private fun uuidFrom(str: String): UUID {
+    val s = str.trim()
+    return when (s.length) {
+        4 -> UUID.fromString("0000$s-0000-1000-8000-00805F9B34FB")
+        8 -> UUID.fromString("$s-0000-1000-8000-00805F9B34FB")
+        else -> UUID.fromString(s)
+    }
+}
+
 private const val TAG = "HassBleSources"
 
 /**
@@ -226,8 +235,8 @@ class NordicGattNotifySource(
             onLinkStatus(DeviceLinkStatus(device.id, DeviceLinkState.Connected, mac))
 
             val services = client.discoverServices()
-            val service = services.findService(UUID.fromString(serviceUuidStr))
-            val characteristic = service?.findCharacteristic(UUID.fromString(notifyCharUuidStr))
+            val service = services.findService(uuidFrom(serviceUuidStr))
+            val characteristic = service?.findCharacteristic(uuidFrom(notifyCharUuidStr))
 
             if (characteristic != null) {
                 Log.d(TAG, "Subscribing to notifications on $notifyCharUuidStr")
@@ -254,8 +263,8 @@ class NordicGattNotifySource(
 
         try {
             val services = client.discoverServices()
-            val service = services.findService(UUID.fromString(serviceUuidStr))
-            val characteristic = service?.findCharacteristic(UUID.fromString(writeCharUuidStr))
+            val service = services.findService(uuidFrom(serviceUuidStr))
+            val characteristic = service?.findCharacteristic(uuidFrom(writeCharUuidStr))
             characteristic?.write(DataByteArray(bytes), BleWriteType.NO_RESPONSE)
         } catch (e: Exception) {
             Log.e(TAG, "Error writing to GATT device ${device.id}", e)
@@ -337,9 +346,9 @@ class NordicElm327Source(
         onLinkStatus(DeviceLinkStatus(device.id, DeviceLinkState.Connected, mac))
 
         val services = client.discoverServices()
-        val service = services.findService(UUID.fromString(serviceUuidStr))
-        val txChar = service?.findCharacteristic(UUID.fromString(txCharUuidStr))
-        val rxChar = service?.findCharacteristic(UUID.fromString(rxCharUuidStr))
+        val service = services.findService(uuidFrom(serviceUuidStr))
+        val txChar = service?.findCharacteristic(uuidFrom(txCharUuidStr))
+        val rxChar = service?.findCharacteristic(uuidFrom(rxCharUuidStr))
             ?: throw IllegalStateException("OBD RX characteristic not found")
 
         if (txChar == null) throw IllegalStateException("OBD TX characteristic not found")
@@ -468,8 +477,8 @@ class NordicElm327Source(
 
         try {
             val services = client.discoverServices()
-            val service = services.findService(UUID.fromString(serviceUuidStr))
-            val characteristic = service?.findCharacteristic(UUID.fromString(txCharUuidStr))
+            val service = services.findService(uuidFrom(serviceUuidStr))
+            val characteristic = service?.findCharacteristic(uuidFrom(txCharUuidStr))
             characteristic?.write(DataByteArray(bytes), BleWriteType.NO_RESPONSE)
         } catch (e: Exception) {
             Log.e(TAG, "Error writing raw hex to OBD dongle ${device.id}", e)

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -57,6 +57,7 @@ data class GattConfig(
     @SerialName("service_uuid") val serviceUuid: String,
     @SerialName("notify_char_uuid") val notifyCharUuid: String,
     @SerialName("write_char_uuid") val writeCharUuid: String? = null,
+    @SerialName("auto_connect") val autoConnect: Boolean = true,
 )
 
 @Serializable
@@ -67,6 +68,7 @@ data class ObdConfig(
     @SerialName("rx_char_uuid") val rxCharUuid: String = "FFF1",
     @SerialName("tx_delay") val txDelay: String = "50ms",
     @SerialName("init_commands") val initCommands: List<String> = emptyList(),
+    @SerialName("auto_connect") val autoConnect: Boolean = true,
 )
 
 @Serializable

--- a/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
@@ -34,6 +34,7 @@ class HassSettingsRepository(private val context: Context) {
         private val KEY_SCAN_MODE = stringPreferencesKey("ble_scan_mode")
         private val KEY_DISABLED_DEVICES = stringPreferencesKey("disabled_devices")
         private val KEY_KNOWN_DEVICE_IDS = stringPreferencesKey("known_device_ids")
+        private val KEY_AUTO_CONNECT_DISABLED = stringPreferencesKey("auto_connect_disabled")
     }
 
     val haUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -101,6 +102,42 @@ class HassSettingsRepository(private val context: Context) {
 
     suspend fun clearDisabledDevices() {
         context.dataStore.edit { prefs -> prefs.remove(KEY_DISABLED_DEVICES) }
+    }
+
+    val autoConnectDisabled: Flow<Set<String>> = context.dataStore.data.map { prefs ->
+        runCatching {
+            json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_AUTO_CONNECT_DISABLED] ?: "[]").toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    suspend fun setAutoConnectDisabled(deviceId: String, disabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            val current = runCatching {
+                json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_AUTO_CONNECT_DISABLED] ?: "[]").toMutableSet()
+            }.getOrDefault(mutableSetOf())
+            if (disabled) current.add(deviceId) else current.remove(deviceId)
+            prefs[KEY_AUTO_CONNECT_DISABLED] = json.encodeToString(ListSerializer(String.serializer()), current.sorted())
+        }
+    }
+
+    suspend fun initAutoConnectFromConfig(devices: List<DeviceConfig>) {
+        context.dataStore.edit { prefs ->
+            val current = runCatching {
+                json.decodeFromString(ListSerializer(String.serializer()), prefs[KEY_AUTO_CONNECT_DISABLED] ?: "[]").toMutableSet()
+            }.getOrDefault(mutableSetOf())
+            // config에서 auto_connect: false인 기기는 강제로 disabled에 추가
+            // config에서 auto_connect: true(기본)인 기기는 기존 사용자 설정 유지
+            devices.filter { it.source == Source.gatt_notify || it.source == Source.obd }
+                .forEach { d ->
+                    val autoConnect = when (d.source) {
+                        Source.gatt_notify -> d.gatt?.autoConnect != false
+                        Source.obd -> d.obd?.autoConnect != false
+                        else -> true
+                    }
+                    if (!autoConnect) current.add(d.id) else current.remove(d.id)
+                }
+            prefs[KEY_AUTO_CONNECT_DISABLED] = json.encodeToString(ListSerializer(String.serializer()), current.sorted())
+        }
     }
 
     suspend fun getRemovedDeviceIds(newConfigIds: Set<String>): Set<String> {

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -101,6 +101,13 @@ class BleGatewayService : Service() {
             return START_STICKY
         }
 
+        if (intent?.action == ACTION_SET_AUTO_CONNECT) {
+            val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            val enabled = intent.getBooleanExtra(EXTRA_AUTO_CONNECT, true)
+            scope.launch { HassSettingsRepository(this@BleGatewayService).setAutoConnectDisabled(deviceId, !enabled) }
+            return START_STICKY
+        }
+
         val haUrl = intent?.getStringExtra(EXTRA_HA_URL) ?: return START_NOT_STICKY
         val token = intent.getStringExtra(EXTRA_TOKEN) ?: return START_NOT_STICKY
         currentGitUrl = intent.getStringExtra(EXTRA_GIT_URL) ?: return START_NOT_STICKY
@@ -182,6 +189,7 @@ class BleGatewayService : Service() {
                 removedIds.forEach { deviceId -> ws?.removeEntitiesByDeviceIdPrefix(deviceId) }
             }
             repository.updateKnownDeviceIds(newConfigIds)
+            repository.initAutoConnectFromConfig(config.devices)
 
             if (runtime == null) {
                 val onLinkStatus: (DeviceLinkStatus) -> Unit = { status ->
@@ -220,17 +228,23 @@ class BleGatewayService : Service() {
                     repository.enabledSensorsInitialized,
                     repository.scanMode,
                     repository.disabledDevices,
+                    repository.autoConnectDisabled,
                 ) { args ->
                     val boundMap = args[0] as Map<*, *>
                     val enabledSensors = args[1] as Set<*>
                     val initialized = args[2] as Boolean
                     val scanMode = args[3] as dev.eigger.hassble.config.BleScanModeOption
                     val disabledDevices = args[4] as Set<*>
+                    val autoConnectDisabled = args[5] as Set<*>
                     val effectiveEnabled = if (!initialized) defaultEnabled else enabledSensors.filterIsInstance<String>().toSet()
-                    Pair(Triple(boundMap.entries.associate { it.key.toString() to it.value.toString() }, effectiveEnabled, scanMode), disabledDevices.filterIsInstance<String>().toSet())
-                }.collect { (triple, disabledDevices) ->
+                    Triple(
+                        Triple(boundMap.entries.associate { it.key.toString() to it.value.toString() }, effectiveEnabled, scanMode),
+                        disabledDevices.filterIsInstance<String>().toSet(),
+                        autoConnectDisabled.filterIsInstance<String>().toSet(),
+                    )
+                }.collect { (triple, disabledDevices, autoConnectDisabled) ->
                     val (boundMap, effectiveEnabled, scanMode) = triple
-                    runtime?.apply(config, effectiveEnabled, boundMap, scanMode, disabledDevices)
+                    runtime?.apply(config, effectiveEnabled, boundMap, scanMode, disabledDevices, autoConnectDisabled)
                 }
             }
             updateNotification()
@@ -348,6 +362,8 @@ class BleGatewayService : Service() {
         private const val ACTION_RELOAD_CONFIG = "dev.eigger.hassble.RELOAD_CONFIG"
         private const val ACTION_DISABLE_DEVICE = "dev.eigger.hassble.DISABLE_DEVICE"
         private const val ACTION_ENABLE_DEVICE = "dev.eigger.hassble.ENABLE_DEVICE"
+        private const val ACTION_SET_AUTO_CONNECT = "dev.eigger.hassble.SET_AUTO_CONNECT"
+        private const val EXTRA_AUTO_CONNECT = "auto_connect"
 
         private val _serviceConnectionState = MutableStateFlow(ConnectionState.Disconnected)
         val serviceConnectionState: StateFlow<ConnectionState> = _serviceConnectionState.asStateFlow()
@@ -404,6 +420,13 @@ class BleGatewayService : Service() {
         fun enableDevice(context: Context, deviceId: String) {
             context.startService(Intent(context, BleGatewayService::class.java)
                 .setAction(ACTION_ENABLE_DEVICE).putExtra(EXTRA_DEVICE_ID, deviceId))
+        }
+
+        fun setAutoConnect(context: Context, deviceId: String, enabled: Boolean) {
+            context.startService(Intent(context, BleGatewayService::class.java)
+                .setAction(ACTION_SET_AUTO_CONNECT)
+                .putExtra(EXTRA_DEVICE_ID, deviceId)
+                .putExtra(EXTRA_AUTO_CONNECT, enabled))
         }
     }
 }

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -224,6 +224,7 @@ private fun HomeScreen() {
     val usingCachedConfigService by BleGatewayService.usingCachedConfig.collectAsState()
     val deviceLinkStatuses by BleGatewayService.deviceLinkStatuses.collectAsState()
     val disabledDeviceIds by repository.disabledDevices.collectAsState(initial = emptySet())
+    val autoConnectDisabledIds by repository.autoConnectDisabled.collectAsState(initial = emptySet())
     val discoveredAdv by BleGatewayService.discoveredAdvInstances.collectAsState()
     val sensorLastValues by BleGatewayService.sensorLastValues.collectAsState()
 
@@ -400,6 +401,7 @@ private fun HomeScreen() {
                     boundDevices = boundDevices,
                     enabledSensors = effectiveEnabledSensors,
                     disabledDeviceIds = disabledDeviceIds,
+                    autoConnectDisabledIds = autoConnectDisabledIds,
                     discoveredAdv = discoveredAdv,
                     sensorLastValues = sensorLastValues,
                     deviceLinkStatuses = deviceLinkStatuses,
@@ -414,6 +416,7 @@ private fun HomeScreen() {
                     },
                     onDisableDevice = { deviceId -> BleGatewayService.disableDevice(context, deviceId) },
                     onEnableDevice = { deviceId -> BleGatewayService.enableDevice(context, deviceId) },
+                    onSetAutoConnect = { deviceId, enabled -> BleGatewayService.setAutoConnect(context, deviceId, enabled) },
                 )
                 2 -> LogsTabContent()
             }
@@ -748,6 +751,7 @@ private fun SensorsTabContent(
     boundDevices: Map<String, String>,
     enabledSensors: Set<String>,
     disabledDeviceIds: Set<String>,
+    autoConnectDisabledIds: Set<String>,
     discoveredAdv: List<DiscoveredAdvInstance>,
     sensorLastValues: List<SensorLastValue>,
     deviceLinkStatuses: List<DeviceLinkStatus>,
@@ -758,6 +762,7 @@ private fun SensorsTabContent(
     onSensorsBulkToggle: (Set<String>, Boolean) -> Unit,
     onDisableDevice: (String) -> Unit,
     onEnableDevice: (String) -> Unit,
+    onSetAutoConnect: (String, Boolean) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -864,6 +869,7 @@ private fun SensorsTabContent(
                     enabledSensors = enabledSensors,
                     isRunning = isRunning,
                     isDisabled = device.id in disabledDeviceIds,
+                    autoConnect = device.id !in autoConnectDisabledIds,
                     discoveredInstances = discoveredAdv.filter { it.profileId == device.id },
                     sensorLastValues = sensorLastValues.filter { it.profileId == device.id },
                     linkStatus = deviceLinkStatuses.firstOrNull { it.profileId == device.id },
@@ -873,6 +879,7 @@ private fun SensorsTabContent(
                     onUnbindClick = { onUnbindClick(device.id) },
                     onDisable = { onDisableDevice(device.id) },
                     onEnable = { onEnableDevice(device.id) },
+                    onSetAutoConnect = { enabled -> onSetAutoConnect(device.id, enabled) },
                 )
             }
         }
@@ -913,6 +920,7 @@ private fun DeviceConfigCard(
     enabledSensors: Set<String>,
     isRunning: Boolean,
     isDisabled: Boolean,
+    autoConnect: Boolean,
     discoveredInstances: List<DiscoveredAdvInstance>,
     sensorLastValues: List<SensorLastValue>,
     linkStatus: DeviceLinkStatus?,
@@ -922,6 +930,7 @@ private fun DeviceConfigCard(
     onUnbindClick: () -> Unit,
     onDisable: () -> Unit,
     onEnable: () -> Unit,
+    onSetAutoConnect: (Boolean) -> Unit,
 ) {
     val deviceSensorKeys = remember(device.id, device.sensors) {
         device.sensors.map { "${device.id}/${it.key}" }
@@ -1292,6 +1301,25 @@ private fun DeviceConfigCard(
                         discoveredInstances = discoveredInstances,
                     )
 
+                    if (isRunning && (device.source == Source.gatt_notify || device.source == Source.obd)) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text("자동 연결", fontSize = 12.sp, color = Color.Gray)
+                            Switch(
+                                checked = autoConnect,
+                                onCheckedChange = { onSetAutoConnect(it) },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = Color.Black,
+                                    checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                ),
+                            )
+                        }
+                    }
+
                     if (isRunning) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -1606,7 +1634,7 @@ private fun LogsTabContent() {
     LaunchedEffect(isLiveActive) {
         if (isLiveActive) {
             LiveEventLogger.logFlow.collect { logLine ->
-                if (logsList.size >= 1000) {
+                if (logsList.size >= 500) {
                     logsList.removeAt(0)
                 }
                 logsList.add(logLine)

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">HassBle</string>
-    <string name="app_sub_title">Home Assistant BLE 브릿지</string>
+    <string name="app_sub_title">Home Assistant BLE 게이트웨이</string>
     <string name="system_monitor">시스템 모니터</string>
     <string name="service_running">서비스 작동</string>
     <string name="status_running">실행 중</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">HassBle</string>
-    <string name="app_sub_title">Home Assistant BLE Bridge</string>
+    <string name="app_sub_title">Home Assistant BLE Gateway</string>
     <string name="system_monitor">System Monitor</string>
     <string name="service_running">Service Running</string>
     <string name="status_running">Running</string>


### PR DESCRIPTION
… support, log/name fixes

- OBD/GATT auto_connect option: config default + UI toggle per device card
- Link state sensor (diagnostic) declared for each OBD/GATT device
- Short UUID (4/8 char) auto-expanded to full 128-bit in GATT/OBD connections
- Log max lines reduced from 1000 to 500
- App subtitle changed from Bridge to Gateway