### PR TITLE
Move token refresh to BleGatewayService to cover manual restarts; bum…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 30
-        versionName = "0.3.1"
+        versionCode = 31
+        versionName = "0.3.2"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -25,6 +25,7 @@ import dev.eigger.hassble.net.ConnectionIssue
 import dev.eigger.hassble.net.ConnectionState
 import dev.eigger.hassble.net.DeviceRef
 import dev.eigger.hassble.net.EntityMsg
+import dev.eigger.hassble.net.HaAuthHelper
 import dev.eigger.hassble.net.HaWsClient
 import dev.eigger.hassble.ui.MainActivity
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -117,10 +119,29 @@ class BleGatewayService : Service() {
         currentGitToken = intent.getStringExtra(EXTRA_GIT_TOKEN)
  
         if (ws == null) {
-            setupWebSocket(haUrl, token, refreshToken)
+            scope.launch {
+                val activeToken = maybeRefreshToken(haUrl, token, refreshToken)
+                setupWebSocket(haUrl, activeToken, refreshToken)
+            }
         }
         reloadConfig()
         return START_STICKY
+    }
+
+    private suspend fun maybeRefreshToken(haUrl: String, token: String, refreshToken: String?): String {
+        if (refreshToken.isNullOrBlank()) return token
+        val repo = HassSettingsRepository(applicationContext)
+        val lastRefreshed = repo.haTokenLastRefreshed.first()
+        if (System.currentTimeMillis() - lastRefreshed <= TOKEN_EXPIRY_MS) return token
+        val result = HaAuthHelper.refreshAccessToken(haUrl, refreshToken)
+        return if (result.isSuccess) {
+            val newToken = result.getOrThrow()
+            repo.saveHaSettings(haUrl, newToken)
+            repo.saveHaTokenLastRefreshed(System.currentTimeMillis())
+            newToken
+        } else {
+            token
+        }
     }
 
     private fun setupWebSocket(haUrl: String, token: String, refreshToken: String?) {
@@ -435,6 +456,7 @@ class BleGatewayService : Service() {
     companion object {
         private const val CHANNEL_ID = "ble_gateway"
         private const val NOTIF_ID = 1
+        private const val TOKEN_EXPIRY_MS = 25 * 60 * 1000L
         const val EXTRA_HA_URL = "ha_url"
         const val EXTRA_TOKEN = "token"
         const val EXTRA_REFRESH_TOKEN = "refresh_token"

--- a/app/src/main/java/dev/eigger/hassble/service/BootReceiver.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BootReceiver.kt
@@ -5,14 +5,12 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import dev.eigger.hassble.config.HassSettingsRepository
-import dev.eigger.hassble.net.HaAuthHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 private const val TAG = "HassBleBootReceiver"
-private const val TOKEN_EXPIRY_MS = 25 * 60 * 1000L // 25분 (HA OAuth 수명 30분보다 보수적)
 
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -22,47 +20,22 @@ class BootReceiver : BroadcastReceiver() {
 
             CoroutineScope(Dispatchers.IO).launch {
                 val startOnBoot = repository.startOnBoot.first()
-                if (!startOnBoot) {
-                    Log.d(TAG, "Start on boot is disabled by user")
-                    return@launch
-                }
+                if (startOnBoot) {
+                    val url = repository.haUrl.first()
+                    val token = repository.haToken.first()
+                    val refreshToken = repository.haRefreshToken.first()
+                    val gitUrl = repository.gitUrl.first()
+                    val gitToken = repository.gitToken.first()
 
-                val url = repository.haUrl.first()
-                val refreshToken = repository.haRefreshToken.first()
-                val gitUrl = repository.gitUrl.first()
-                val gitToken = repository.gitToken.first()
-
-                if (url.isBlank() || gitUrl.isBlank()) {
-                    Log.d(TAG, "HassBle settings are incomplete, skipping auto-start")
-                    return@launch
-                }
-
-                // 토큰 만료 여부 확인 — 만료됐으면 연결 전에 미리 갱신해 HA ban 알림 방지
-                var token = repository.haToken.first()
-                if (token.isBlank()) {
-                    Log.d(TAG, "HassBle settings are incomplete, skipping auto-start")
-                    return@launch
-                }
-
-                if (refreshToken.isNotBlank()) {
-                    val lastRefreshed = repository.haTokenLastRefreshed.first()
-                    val tokenAge = System.currentTimeMillis() - lastRefreshed
-                    if (tokenAge > TOKEN_EXPIRY_MS) {
-                        Log.d(TAG, "Access token may be expired (age: ${tokenAge / 1000}s), refreshing before connect...")
-                        val result = HaAuthHelper.refreshAccessToken(url, refreshToken)
-                        if (result.isSuccess) {
-                            token = result.getOrThrow()
-                            repository.saveHaSettings(url, token)
-                            repository.saveHaTokenLastRefreshed(System.currentTimeMillis())
-                            Log.d(TAG, "Token refreshed successfully before boot connect")
-                        } else {
-                            Log.w(TAG, "Token refresh failed, will retry after auth_invalid: ${result.exceptionOrNull()?.message}")
-                        }
+                    if (url.isNotBlank() && token.isNotBlank() && gitUrl.isNotBlank()) {
+                        Log.d(TAG, "Settings found, starting BleGatewayService")
+                        BleGatewayService.start(context, url, token, refreshToken, gitUrl, gitToken)
+                    } else {
+                        Log.d(TAG, "HassBle settings are incomplete, skipping auto-start")
                     }
+                } else {
+                    Log.d(TAG, "Start on boot is disabled by user")
                 }
-
-                Log.d(TAG, "Settings found, starting BleGatewayService")
-                BleGatewayService.start(context, url, token, refreshToken, gitUrl, gitToken)
             }
         }
     }


### PR DESCRIPTION
…p v0.3.2

Previous fix only refreshed the token in BootReceiver (boot path). Manual service stop/start bypasses BootReceiver so the expired token was still used, triggering HA ban notifications.

Move maybeRefreshToken() into BleGatewayService.onStartCommand() so all start paths (boot and manual) proactively refresh the token before opening the WebSocket connection. BootReceiver reverts to simple settings-read and service start.