### PR TITLE
Use JWT exp claim to gate token refresh instead of refreshing on ever…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 32
-        versionName = "0.3.3"
+        versionCode = 33
+        versionName = "0.3.4"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/net/HaAuthHelper.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaAuthHelper.kt
@@ -66,6 +66,17 @@ object HaAuthHelper {
         }
     }
 
+    fun isTokenExpiringSoon(token: String, thresholdMs: Long = 5 * 60 * 1000L): Boolean {
+        return try {
+            val payload = token.split(".").getOrNull(1) ?: return true
+            val decoded = String(android.util.Base64.decode(payload, android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING))
+            val exp = org.json.JSONObject(decoded).getLong("exp") * 1000L
+            System.currentTimeMillis() > exp - thresholdMs
+        } catch (e: Exception) {
+            true
+        }
+    }
+
     fun refreshAccessToken(haUrl: String, refreshToken: String): Result<String> {
         val cleanUrl = haUrl.trimEnd('/')
         val url = "$cleanUrl/auth/token"

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -126,7 +126,7 @@ class HaWsClient(
         if (_connectionState.value == ConnectionState.Disconnected) {
             reconnectDelayMs = 500L
             scope.launch {
-                if (!refreshToken.isNullOrBlank()) {
+                if (!refreshToken.isNullOrBlank() && HaAuthHelper.isTokenExpiringSoon(token)) {
                     val result = withContext(Dispatchers.IO) {
                         HaAuthHelper.refreshAccessToken(baseUrl, refreshToken)
                     }
@@ -302,7 +302,7 @@ class HaWsClient(
         scope.launch {
             delay(reconnectDelayMs)
             reconnectDelayMs = (reconnectDelayMs * 2).coerceAtMost(30000L)
-            if (!refreshToken.isNullOrBlank()) {
+            if (!refreshToken.isNullOrBlank() && HaAuthHelper.isTokenExpiringSoon(token)) {
                 val result = withContext(Dispatchers.IO) {
                     HaAuthHelper.refreshAccessToken(baseUrl, refreshToken)
                 }

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -130,14 +129,11 @@ class BleGatewayService : Service() {
 
     private suspend fun maybeRefreshToken(haUrl: String, token: String, refreshToken: String?): String {
         if (refreshToken.isNullOrBlank()) return token
-        val repo = HassSettingsRepository(applicationContext)
-        val lastRefreshed = repo.haTokenLastRefreshed.first()
-        if (System.currentTimeMillis() - lastRefreshed <= TOKEN_EXPIRY_MS) return token
+        if (!HaAuthHelper.isTokenExpiringSoon(token)) return token
         val result = HaAuthHelper.refreshAccessToken(haUrl, refreshToken)
         return if (result.isSuccess) {
             val newToken = result.getOrThrow()
-            repo.saveHaSettings(haUrl, newToken)
-            repo.saveHaTokenLastRefreshed(System.currentTimeMillis())
+            HassSettingsRepository(applicationContext).saveHaSettings(haUrl, newToken)
             newToken
         } else {
             token
@@ -153,9 +149,7 @@ class BleGatewayService : Service() {
             scope = scope,
             refreshToken = refreshToken,
             onTokenRefreshed = { newToken ->
-                val repo = HassSettingsRepository(applicationContext)
-                repo.saveHaSettings(haUrl, newToken)
-                repo.saveHaTokenLastRefreshed(System.currentTimeMillis())
+                HassSettingsRepository(applicationContext).saveHaSettings(haUrl, newToken)
             }
         ).also {
             it.connect()
@@ -456,7 +450,6 @@ class BleGatewayService : Service() {
     companion object {
         private const val CHANNEL_ID = "ble_gateway"
         private const val NOTIF_ID = 1
-        private const val TOKEN_EXPIRY_MS = 25 * 60 * 1000L
         const val EXTRA_HA_URL = "ha_url"
         const val EXTRA_TOKEN = "token"
         const val EXTRA_REFRESH_TOKEN = "refresh_token"


### PR DESCRIPTION
…y reconnect; bump v0.3.4

Previously, triggerReconnection() and reconnectImmediately() refreshed the OAuth token unconditionally on every reconnect attempt, which was wasteful during frequent reconnects (network flapping, HA restart).

Now mirrors the HA Companion app approach: parse the exp claim from the JWT access token and only refresh when the token is within 5 minutes of expiry. Also removes the lastRefreshed timestamp tracking from BleGatewayService/repository since the JWT carries its own expiry.