### PR TITLE
Fix NPE crash on Start Gateway: ensure reloadConfig runs after setupW…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 33
-        versionName = "0.3.4"
+        versionCode = 34
+        versionName = "0.3.5"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -121,9 +121,11 @@ class BleGatewayService : Service() {
             scope.launch {
                 val activeToken = maybeRefreshToken(haUrl, token, refreshToken)
                 setupWebSocket(haUrl, activeToken, refreshToken)
+                reloadConfig()
             }
+        } else {
+            reloadConfig()
         }
-        reloadConfig()
         return START_STICKY
     }
 


### PR DESCRIPTION
…ebSocket; bump v0.3.5

onStartCommand() launched setupWebSocket() asynchronously (to allow token refresh before connecting), then immediately called reloadConfig(). reloadConfig() creates BleRuntime with ws!!, but ws was not yet assigned if git config loaded from cache before the token refresh completed.

Fix: call reloadConfig() inside the coroutine, after setupWebSocket() sets ws, so BleRuntime creation never sees a null ws.