### PR TITLE
Bump version to 0.3.9: add log sharing and UI cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 37
-        versionName = "0.3.8"
+        versionCode = 38
+        versionName = "0.3.9"
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,5 +66,15 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
@@ -27,11 +27,28 @@ object LiveEventLogger {
     private val _logFlow = MutableSharedFlow<LogEntry>(extraBufferCapacity = 500)
     val logFlow = _logFlow.asSharedFlow()
 
+    private val _logs = mutableListOf<LogEntry>()
+    val logs: List<LogEntry>
+        get() = synchronized(_logs) { ArrayList(_logs) }
+
     private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
 
     fun log(type: LogType, message: String) {
         if (!isLiveActive) return
         val timestamp = dateFormat.format(Date())
-        _logFlow.tryEmit(LogEntry(timestamp, type, message))
+        val entry = LogEntry(timestamp, type, message)
+        synchronized(_logs) {
+            if (_logs.size >= 500) {
+                _logs.removeAt(0)
+            }
+            _logs.add(entry)
+        }
+        _logFlow.tryEmit(entry)
+    }
+
+    fun clearLogs() {
+        synchronized(_logs) {
+            _logs.clear()
+        }
     }
 }

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -630,9 +630,6 @@ private fun GatewayTabContent(
     var isTestingConnection by remember { mutableStateOf(false) }
     var showClearOAuthDialog by remember { mutableStateOf(false) }
     val issueMessage = connectionIssueMessage(connectionIssue)
-    val gatewayId = remember {
-        android.provider.Settings.Secure.getString(context.contentResolver, android.provider.Settings.Secure.ANDROID_ID) ?: "hassble"
-    }
 
     if (showClearOAuthDialog) {
         Dialog(onDismissRequest = { showClearOAuthDialog = false }) {
@@ -677,17 +674,6 @@ private fun GatewayTabContent(
                     ConnectionState.Disconnected -> stringResource(R.string.status_disconnected)
                 }, isHighlighted = connState == ConnectionState.Connected)
                 StatusRow(label = stringResource(R.string.gateway_model), value = Build.MODEL, isHighlighted = false)
-                StatusRow(
-                    label = stringResource(R.string.gateway_id_click_to_copy),
-                    value = gatewayId,
-                    isHighlighted = false,
-                    onClick = {
-                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                        val clip = android.content.ClipData.newPlainText("Gateway ID", gatewayId)
-                        clipboard.setPrimaryClip(clip)
-                        Toast.makeText(context, context.getString(R.string.gateway_id_copied), Toast.LENGTH_SHORT).show()
-                    }
-                )
                 if (issueMessage != null) {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(text = issueMessage, color = MaterialTheme.colorScheme.error, fontSize = 12.sp)
@@ -1973,8 +1959,13 @@ private fun StatusBadge(isRunning: Boolean, connState: ConnectionState, connecti
 
 @Composable
 private fun LogsTabContent() {
+    val context = LocalContext.current
     var isLiveActive by remember { mutableStateOf(LiveEventLogger.isLiveActive) }
-    val logsList = remember { mutableStateListOf<LogEntry>() }
+    val logsList = remember {
+        mutableStateListOf<LogEntry>().apply {
+            addAll(LiveEventLogger.logs)
+        }
+    }
     var filterText by remember { mutableStateOf("") }
 
     LaunchedEffect(isLiveActive) {
@@ -2030,7 +2021,23 @@ private fun LogsTabContent() {
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Button(
-                        onClick = { logsList.clear() },
+                        onClick = {
+                            shareLogs(context, logsList)
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color.White.copy(alpha = 0.08f),
+                            contentColor = Color.White
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
+                    ) {
+                        Text(stringResource(R.string.logs_share), fontSize = 12.sp)
+                    }
+                    Button(
+                        onClick = {
+                            logsList.clear()
+                            LiveEventLogger.clearLogs()
+                        },
                         colors = ButtonDefaults.buttonColors(
                             containerColor = Color.White.copy(alpha = 0.08f),
                             contentColor = Color.White
@@ -2189,6 +2196,31 @@ private fun LogsTabContent() {
                 }
             }
         }
+    }
+}
+
+private fun shareLogs(context: Context, logs: List<LogEntry>) {
+    if (logs.isEmpty()) {
+        Toast.makeText(context, "No logs to share", Toast.LENGTH_SHORT).show()
+        return
+    }
+    val logString = logs.joinToString("\n") { "[${it.timestamp}] [${it.type.name}] ${it.message}" }
+    try {
+        val file = java.io.File(context.cacheDir, "hassble_logs.txt")
+        file.writeText(logString)
+        val uri = androidx.core.content.FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.logs_share)))
+    } catch (e: Exception) {
+        Toast.makeText(context, "Failed to share logs: ${e.message}", Toast.LENGTH_LONG).show()
     }
 }
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -13,7 +13,6 @@
     <string name="gateway_model">게이트웨이 모델</string>
     <string name="server_integration_settings">서버 및 연동 설정</string>
     <string name="long_lived_token">장기 액세스 토큰</string>
-    <string name="git_config_url">설정 git URL (raw YAML)</string>
     <string name="git_token_optional">Git 액세스 토큰 (선택)</string>
     <string name="devices_adapters_list">기기 및 어댑터 리스트</string>
     <string name="config_load_error">설정을 로드할 수 없습니다:\n%1$s</string>
@@ -24,7 +23,6 @@
     <string name="source_advertisement">광고 수신</string>
     <string name="source_gatt_notify">GATT 연결</string>
     <string name="source_obd">OBD 폴링</string>
-    <string name="sensor_list">센서 목록:</string>
     <string name="auto_detecting">자동 탐색 수집 중</string>
     <string name="bound_in_config">설정에 고정됨 (MAC: %1$s)</string>
     <string name="connected_mac">연결됨: %1$s</string>
@@ -62,8 +60,6 @@
     <string name="status_badge_connecting">연결 중</string>
     <string name="status_badge_error">오류</string>
     <string name="sensor_edit_locked_running">활성 센서를 수정하려면 게이트웨이를 먼저 정지하세요.</string>
-    <string name="instance_mode_mac">인스턴스 모드: MAC별</string>
-    <string name="instance_mode_shared">인스턴스 모드: 공유 엔티티</string>
     <string name="adv_reg_mac_per_device">MAC별 엔티티</string>
     <string name="adv_reg_fixed_mac">고정 MAC (%1$s)</string>
     <string name="adv_reg_shared">공유 엔티티</string>
@@ -73,7 +69,6 @@
     <string name="adv_instance_entity_id">엔티티: %1$s</string>
     <string name="adv_instance_mac_based">MAC 기반</string>
     <string name="adv_instance_not_mac_based">MAC 기반 아님</string>
-    <string name="sensor_last_values">마지막 값</string>
     <string name="sensor_no_data">아직 데이터 없음</string>
     <string name="sensor_value_updated">%1$s · %2$s</string>
     <string name="discovered_devices_waiting">게이트웨이를 시작하면 BLE 광고 기기를 탐지합니다.</string>
@@ -141,10 +136,10 @@
     <string name="notif_auth_failed">인증 실패 — 토큰 확인</string>
     <string name="notif_bridge_timeout">ws_bridge 응답 없음</string>
     <string name="notif_config_error">설정 로드 실패</string>
-    <string name="settings_saved">설정이 저장되었습니다</string>
     <string name="tab_logs">로그</string>
     <string name="live_logs_enable">라이브 활성화</string>
     <string name="logs_clear">지우기</string>
+    <string name="logs_share">공유</string>
     <string name="logs_filter_placeholder">로그 필터 (예: 맥주소, 제조사 번호, OBD…)</string>
     <string name="oauth_login_btn">HA OAuth 로그인</string>
     <string name="ha_url_required_toast">HA URL을 먼저 입력해주세요.</string>
@@ -173,8 +168,6 @@
     <string name="time_just_now">방금 전</string>
     <string name="time_minutes_ago">%1$d분 전</string>
     <string name="time_hours_ago">%1$d시간 전</string>
-    <string name="gateway_id_click_to_copy">게이트웨이 ID (클릭하여 복사)</string>
-    <string name="gateway_id_copied">게이트웨이 ID가 복사되었습니다.</string>
     <string name="ble_scan_mode">BLE 스캔 모드</string>
     <string name="scan_mode_low_power">절전 (광고 수신 불안정)</string>
     <string name="scan_mode_balanced">균형</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="gateway_model">Gateway Model</string>
     <string name="server_integration_settings">Server &amp; Integration Settings</string>
     <string name="long_lived_token">Long-lived Access Token</string>
-    <string name="git_config_url">Config Git URL (raw YAML)</string>
     <string name="git_token_optional">Git Access Token (Optional)</string>
     <string name="devices_adapters_list">Devices &amp; Adapters</string>
     <string name="config_load_error">Cannot load configuration:\n%1$s</string>
@@ -24,7 +23,6 @@
     <string name="source_advertisement">Passive Scan</string>
     <string name="source_gatt_notify">GATT Connection</string>
     <string name="source_obd">OBD Polling</string>
-    <string name="sensor_list">Sensor List:</string>
     <string name="auto_detecting">Auto-detecting</string>
     <string name="bound_in_config">Fixed in Config (MAC: %1$s)</string>
     <string name="connected_mac">Connected: %1$s</string>
@@ -62,8 +60,6 @@
     <string name="status_badge_connecting">Connecting</string>
     <string name="status_badge_error">Error</string>
     <string name="sensor_edit_locked_running">Stop gateway to edit enabled sensors.</string>
-    <string name="instance_mode_mac">Instance mode: per MAC</string>
-    <string name="instance_mode_shared">Instance mode: shared entity</string>
     <string name="adv_reg_mac_per_device">Per-MAC entity</string>
     <string name="adv_reg_fixed_mac">Fixed MAC (%1$s)</string>
     <string name="adv_reg_shared">Shared entity</string>
@@ -73,7 +69,6 @@
     <string name="adv_instance_entity_id">Entity: %1$s</string>
     <string name="adv_instance_mac_based">MAC-based</string>
     <string name="adv_instance_not_mac_based">Not MAC-based</string>
-    <string name="sensor_last_values">Last values</string>
     <string name="sensor_no_data">No data yet</string>
     <string name="sensor_value_updated">%1$s · %2$s</string>
     <string name="discovered_devices_waiting">Start gateway to discover BLE advertisers.</string>
@@ -148,10 +143,10 @@
     <string name="notif_auth_failed">Auth failed — check token</string>
     <string name="notif_bridge_timeout">ws_bridge not responding</string>
     <string name="notif_config_error">Config load failed</string>
-    <string name="settings_saved">Settings saved</string>
     <string name="tab_logs">Logs</string>
     <string name="live_logs_enable">Live Logs</string>
     <string name="logs_clear">Clear</string>
+    <string name="logs_share">Share</string>
     <string name="logs_filter_placeholder">Filter logs (e.g. MAC, mfr ID, OBD…)</string>
     <string name="oauth_login_btn">HA OAuth Login</string>
     <string name="ha_url_required_toast">Please enter HA URL first.</string>
@@ -180,8 +175,6 @@
     <string name="time_just_now">Just now</string>
     <string name="time_minutes_ago">%1$d mins ago</string>
     <string name="time_hours_ago">%1$d hours ago</string>
-    <string name="gateway_id_click_to_copy">Gateway ID (Click to copy)</string>
-    <string name="gateway_id_copied">Gateway ID copied to clipboard.</string>
     <string name="ble_scan_mode">BLE Scan Mode</string>
     <string name="scan_mode_low_power">Power Saving (Unstable advertisement reception)</string>
     <string name="scan_mode_balanced">Balanced</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="logs" path="." />
+</paths>


### PR DESCRIPTION
Add log export via FileProvider, persist live logs for tab restore, remove unused gateway ID UI and dead string resources.