### PR TITLE
Use ws_bridge/remove prefix mode for MAC advertisement deletion (v0.3…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 42
-        versionName = "0.3.13"
+        versionCode = 43
+        versionName = "0.3.14"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -169,9 +169,10 @@ class BleRuntime(
         // 1. Remove deleted devices
         val deletedIds = oldDeviceIds - currentDeviceIds
         for (id in deletedIds) {
+            val mode = haRemoveModeForDevice(oldConfig.devices.firstOrNull { it.id == id })
             stopDevice(id)
             scope.launch {
-                runCatching { ws.removeEntitiesByDeviceIdPrefix(id) }
+                runCatching { ws.removeDevice(id, mode) }
             }
         }
 
@@ -203,10 +204,11 @@ class BleRuntime(
                 if (needsHaCleanup) {
                     // 센서 platform/type이 바뀐 경우: HA 구 엔티티를 먼저 삭제 후 재선언
                     val capturedD = d
+                    val cleanupMode = haRemoveModeForDevice(capturedD)
                     pendingHaCleanupIds.add(capturedD.id)
                     scope.launch {
                         try {
-                            runCatching { ws.removeEntitiesByDeviceIdPrefix(capturedD.id) }
+                            runCatching { ws.removeDevice(capturedD.id, cleanupMode) }
                             // cleanup이 진행되는 동안 기기가 삭제/제외됐다면 재기동하지 않는다.
                             if (lastConfig?.devices?.any { it.id == capturedD.id } == true) {
                                 startDevice(capturedD)
@@ -540,12 +542,19 @@ class BleRuntime(
 
     /**
      * 기기 삭제 시 config 재로드(네트워크)를 기다리지 않고 즉시 BLE 연결/스캔 상태를 정리한다.
-     * HA 엔티티 제거는 호출 측에서 별도로 처리한다.
+     * HA 엔티티 제거는 호출 측에서 [haRemoveModeForDeviceId]와 [dev.eigger.hassble.net.HaWsClient.removeDevice]로 처리한다.
      */
     fun stopDeviceNow(deviceId: String) {
         if (!::config.isInitialized) return
         stopDevice(deviceId)
     }
+
+    /** 삭제·HA 정리 요청 전에 호출 — [devices]가 비워지기 전에 remove mode를 결정한다. */
+    fun haRemoveModeForDeviceId(deviceId: String) = haRemoveModeForDevice(
+        devices[deviceId]
+            ?: if (::config.isInitialized) config.devices.firstOrNull { it.id == deviceId } else null
+            ?: lastConfig?.devices?.firstOrNull { it.id == deviceId },
+    )
 
     /** 게이트웨이 실행 중 특정 기기를 수동으로 연결 시작. */
     fun connectDevice(deviceId: String) {

--- a/app/src/main/java/dev/eigger/hassble/ble/HaRemoveMode.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/HaRemoveMode.kt
@@ -1,0 +1,16 @@
+package dev.eigger.hassble.ble
+
+import dev.eigger.hassble.config.AdvertisementInstanceMode
+import dev.eigger.hassble.config.DeviceConfig
+import dev.eigger.hassble.config.Source
+import dev.eigger.hassble.net.HaRemoveMode
+
+/** ws_bridge/remove mode: MAC 인스턴스 advertisement 프로필은 prefix 삭제. */
+fun haRemoveModeForDevice(d: DeviceConfig?): HaRemoveMode = when {
+    d != null &&
+        d.source == Source.advertisement &&
+        d.instanceMode == AdvertisementInstanceMode.mac &&
+        d.match?.mac.isNullOrBlank() ->
+        HaRemoveMode.PREFIX
+    else -> HaRemoveMode.EXACT
+}

--- a/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
+import dev.eigger.hassble.net.HaRemoveMode
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "hassble_settings")
 
@@ -42,6 +43,7 @@ class HassSettingsRepository(private val context: Context) {
         private val KEY_ENTITY_FINGERPRINTS = stringPreferencesKey("entity_fingerprints")
         private val KEY_DRAFT_DEVICES = stringPreferencesKey("draft_devices")
         private val KEY_PENDING_HA_REMOVALS = stringPreferencesKey("pending_ha_removals")
+        private val KEY_PENDING_HA_REMOVAL_MODES = stringPreferencesKey("pending_ha_removal_modes")
         private val KEY_EXCLUDED_DEVICES = stringPreferencesKey("excluded_devices")
         private val KEY_LOG_BUFFER_LIMIT = intPreferencesKey("log_buffer_limit")
     }
@@ -169,29 +171,54 @@ class HassSettingsRepository(private val context: Context) {
     }
 
     /** 게이트웨이 중단·WS 미연결 시에도 다음 연결 때 HA 엔티티를 제거할 수 있도록 대기열에 넣는다. */
-    suspend fun queueHaEntityRemoval(deviceIds: Collection<String>) {
+    suspend fun queueHaEntityRemoval(
+        deviceIds: Collection<String>,
+        modes: Map<String, HaRemoveMode> = emptyMap(),
+    ) {
         if (deviceIds.isEmpty()) return
         val stringList = ListSerializer(String.serializer())
+        val stringMap = MapSerializer(String.serializer(), String.serializer())
         context.dataStore.edit { prefs ->
             val current = runCatching {
                 json.decodeFromString(stringList, prefs[KEY_PENDING_HA_REMOVALS] ?: "[]").toMutableSet()
             }.getOrDefault(mutableSetOf())
             current += deviceIds
             prefs[KEY_PENDING_HA_REMOVALS] = json.encodeToString(stringList, current.sorted())
+            if (modes.isNotEmpty()) {
+                val modeMap = runCatching {
+                    json.decodeFromString(stringMap, prefs[KEY_PENDING_HA_REMOVAL_MODES] ?: "{}").toMutableMap()
+                }.getOrDefault(mutableMapOf())
+                modes.forEach { (id, mode) -> modeMap[id] = mode.wireName }
+                prefs[KEY_PENDING_HA_REMOVAL_MODES] = json.encodeToString(stringMap, modeMap)
+            }
         }
     }
 
-    suspend fun consumePendingHaRemovals(): Set<String> {
-        var result = emptySet<String>()
+    /** device id → ws_bridge/remove mode (미저장 시 [HaRemoveMode.EXACT]). */
+    suspend fun consumePendingHaRemovals(): Map<String, HaRemoveMode> {
+        var ids = emptySet<String>()
+        var modeWire = emptyMap<String, String>()
         val stringList = ListSerializer(String.serializer())
+        val stringMap = MapSerializer(String.serializer(), String.serializer())
         context.dataStore.edit { prefs ->
-            val raw = prefs[KEY_PENDING_HA_REMOVALS] ?: return@edit
-            result = runCatching {
-                json.decodeFromString(stringList, raw).toSet()
-            }.getOrDefault(emptySet())
-            prefs.remove(KEY_PENDING_HA_REMOVALS)
+            prefs[KEY_PENDING_HA_REMOVALS]?.let { raw ->
+                ids = runCatching {
+                    json.decodeFromString(stringList, raw).toSet()
+                }.getOrDefault(emptySet())
+                prefs.remove(KEY_PENDING_HA_REMOVALS)
+            }
+            prefs[KEY_PENDING_HA_REMOVAL_MODES]?.let { raw ->
+                modeWire = runCatching {
+                    json.decodeFromString(stringMap, raw)
+                }.getOrDefault(emptyMap())
+                prefs.remove(KEY_PENDING_HA_REMOVAL_MODES)
+            }
         }
-        return result
+        return ids.associateWith { id ->
+            modeWire[id]?.let { wire ->
+                HaRemoveMode.entries.firstOrNull { it.wireName == wire }
+            } ?: HaRemoveMode.EXACT
+        }
     }
 
     suspend fun saveScanMode(mode: BleScanModeOption) {
@@ -371,8 +398,12 @@ class HassSettingsRepository(private val context: Context) {
     }
 
     /** draft 또는 Git config 기기를 앱 로컬 설정과 함께 제거하고 HA 삭제를 대기열에 넣는다. */
-    suspend fun deleteDevice(deviceId: String, isDraft: Boolean) {
-        queueHaEntityRemoval(setOf(deviceId))
+    suspend fun deleteDevice(
+        deviceId: String,
+        isDraft: Boolean,
+        haRemoveMode: HaRemoveMode = HaRemoveMode.EXACT,
+    ) {
+        queueHaEntityRemoval(setOf(deviceId), mapOf(deviceId to haRemoveMode))
         val remainingDraft = if (isDraft) loadDraftDevices().filter { it.id != deviceId } else null
         val stringList = ListSerializer(String.serializer())
         val stringMap = MapSerializer(String.serializer(), String.serializer())

--- a/app/src/main/java/dev/eigger/hassble/net/HaRemoveMode.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaRemoveMode.kt
@@ -1,0 +1,15 @@
+package dev.eigger.hassble.net
+
+/**
+ * [ws_bridge/remove](https://github.com/eigger/hass-ws-bridge/blob/main/docs/PROTOCOL.md) 삭제 범위.
+ */
+enum class HaRemoveMode(val wireName: String) {
+    /** 클라이언트 device.id / unique_id 와 완전 일치하는 대상만 */
+    EXACT("exact"),
+
+    /**
+     * 대상 id와 일치하거나 `target_` 로 시작하는 하위 id 전부.
+     * advertisement instance_mode=mac 프로필 삭제 시 MAC 인스턴스 포함.
+     */
+    PREFIX("prefix"),
+}

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -188,12 +188,15 @@ class HaWsClient(
         }.toString())
     }
 
-    suspend fun removeEntitiesByDeviceIdPrefix(deviceId: String) {
+    suspend fun removeDevice(deviceId: String, mode: HaRemoveMode = HaRemoveMode.EXACT) {
         if (_connectionState.value != ConnectionState.Connected) return
         // ws_bridge/remove 를 사용해야 ws_bridge 내부의 _created set도 함께 정리됨.
         // native config/entity_registry/remove 는 HA 레지스트리만 삭제하고 _created는 그대로 남아
         // 이후 redeclare 시 _create()가 skip되어 엔티티가 재등록되지 않는 버그 발생.
-        sendRequest("$WS_DOMAIN/remove") { put("device_id", deviceId) }
+        sendRequest("$WS_DOMAIN/remove") {
+            put("device_id", deviceId)
+            if (mode != HaRemoveMode.EXACT) put("mode", mode.wireName)
+        }
     }
 
     private suspend fun sendRequest(type: String, build: JsonObjectBuilder.() -> Unit = {}): JsonObject? {

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationCompat
 import dev.eigger.hassble.R
 import dev.eigger.hassble.ble.BleRuntime
 import dev.eigger.hassble.ble.DeviceLinkStatus
+import dev.eigger.hassble.ble.haRemoveModeForDevice
 import dev.eigger.hassble.ble.DiscoveredAdvInstance
 import dev.eigger.hassble.ble.SensorLastValue
 import dev.eigger.hassble.config.ConfigLoader
@@ -25,6 +26,7 @@ import dev.eigger.hassble.net.ConnectionState
 import dev.eigger.hassble.net.DeviceRef
 import dev.eigger.hassble.net.EntityMsg
 import dev.eigger.hassble.net.HaAuthHelper
+import dev.eigger.hassble.net.HaRemoveMode
 import dev.eigger.hassble.net.HaWsClient
 import dev.eigger.hassble.ui.MainActivity
 import kotlinx.coroutines.CoroutineScope
@@ -82,13 +84,14 @@ class BleGatewayService : Service() {
 
         if (intent?.action == ACTION_REMOVE_DEVICE) {
             val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            val mode = haRemoveModeFor(deviceId)
             // config 재로드를 기다리지 않고 BLE 연결/스캔을 즉시 정리한다.
             runtime?.stopDeviceNow(deviceId)
             scope.launch {
                 val repository = HassSettingsRepository(this@BleGatewayService)
-                repository.queueHaEntityRemoval(setOf(deviceId))
+                repository.queueHaEntityRemoval(setOf(deviceId), mapOf(deviceId to mode))
                 pendingEntityCleanupDeviceIds = pendingEntityCleanupDeviceIds + deviceId
-                runCatching { ws?.removeEntitiesByDeviceIdPrefix(deviceId) }
+                runCatching { ws?.removeDevice(deviceId, mode) }
             }
             return START_STICKY
         }
@@ -169,19 +172,22 @@ class BleGatewayService : Service() {
                     val repository = HassSettingsRepository(this@BleGatewayService)
                     val pendingFromStore = repository.consumePendingHaRemovals()
                     // 선언 내용이 바뀐 device의 HA 엔티티를 먼저 제거 후 재선언
-                    val cleanupIds = pendingEntityCleanupDeviceIds + pendingFromStore
+                    val cleanupIds = pendingEntityCleanupDeviceIds + pendingFromStore.keys
                     if (cleanupIds.isNotEmpty()) {
                         pendingEntityCleanupDeviceIds = emptySet()
-                        val failed = mutableSetOf<String>()
+                        val failed = mutableMapOf<String, HaRemoveMode>()
                         for (deviceId in cleanupIds) {
                             val client = ws
+                            val mode = pendingFromStore[deviceId]
+                                ?: runtime?.haRemoveModeForDeviceId(deviceId)
+                                ?: haRemoveModeFor(deviceId)
                             val ok = client != null &&
-                                runCatching { client.removeEntitiesByDeviceIdPrefix(deviceId) }.isSuccess
-                            if (!ok) failed += deviceId
+                                runCatching { client.removeDevice(deviceId, mode) }.isSuccess
+                            if (!ok) failed[deviceId] = mode
                         }
                         // 실패분은 다음 연결에서 다시 시도하도록 대기열에 되돌린다.
-                        if (failed.isNotEmpty()) repository.queueHaEntityRemoval(failed)
-                        val done = cleanupIds - failed
+                        if (failed.isNotEmpty()) repository.queueHaEntityRemoval(failed.keys, failed)
+                        val done = cleanupIds - failed.keys
                         if (done.isNotEmpty()) {
                             LiveEventLogger.log(LogType.LINK,
                                 "Refreshed HA entities for: ${done.joinToString()}")
@@ -280,11 +286,12 @@ class BleGatewayService : Service() {
             val newConfigIds = config.devices.map { it.id }.toSet()
             val removedIds = repository.getRemovedDeviceIds(newConfigIds)
             if (removedIds.isNotEmpty()) {
-                repository.queueHaEntityRemoval(removedIds)
+                val removalModes = removedIds.associateWith { haRemoveModeFor(it) }
+                repository.queueHaEntityRemoval(removedIds, removalModes)
                 pendingEntityCleanupDeviceIds = pendingEntityCleanupDeviceIds + removedIds
                 LiveEventLogger.log(LogType.LINK, "Config 변경: 삭제된 기기 HA 정리 중 (${removedIds.joinToString()})")
                 removedIds.forEach { deviceId ->
-                    runCatching { ws?.removeEntitiesByDeviceIdPrefix(deviceId) }
+                    runCatching { ws?.removeDevice(deviceId, removalModes.getValue(deviceId)) }
                     repository.unbindDevice(deviceId)
                 }
             }
@@ -365,6 +372,11 @@ class BleGatewayService : Service() {
     }
 
     private fun defaultEnabled(config: GatewayConfig): Set<String> = config.allSensorKeys()
+
+    private fun haRemoveModeFor(deviceId: String): HaRemoveMode =
+        runtime?.haRemoveModeForDeviceId(deviceId)
+            ?: haRemoveModeForDevice(currentConfig?.devices?.firstOrNull { it.id == deviceId })
+            ?: HaRemoveMode.EXACT
 
     @android.annotation.SuppressLint("HardwareIds")
     private fun gatewayId(): String =

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -146,6 +146,7 @@ import dev.eigger.hassble.config.ValidationLevel
 import dev.eigger.hassble.config.Source
 import dev.eigger.hassble.ble.DeviceLinkState
 import dev.eigger.hassble.ble.DeviceLinkStatus
+import dev.eigger.hassble.ble.haRemoveModeForDevice
 import dev.eigger.hassble.net.ConnectionIssue
 import dev.eigger.hassble.net.ConnectionState
 import dev.eigger.hassble.net.GitHubHelper
@@ -633,7 +634,10 @@ private fun HomeScreen() {
                     onDeleteDevice = { deviceId ->
                         scope.launch {
                             val isDraft = deviceId in draftDeviceIds
-                            repository.deleteDevice(deviceId, isDraft = isDraft)
+                            val device = draftDevices.firstOrNull { it.id == deviceId }
+                                ?: effectiveConfig?.devices?.firstOrNull { it.id == deviceId }
+                            val mode = haRemoveModeForDevice(device)
+                            repository.deleteDevice(deviceId, isDraft = isDraft, haRemoveMode = mode)
                             draftDevices = repository.loadDraftDevices()
                             // 게이트웨이가 실행 중일 때만 서비스에 알린다.
                             // 중단 상태면 deleteDevice가 대기열에 넣은 HA 삭제가 다음 시작 시 처리된다.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -104,6 +104,32 @@ HA는 받은 것을 그대로 반영만 한다.
 옵션→hex, number template `A1{value:02X}`, button press→hex). hex 매핑은 **앱**이,
 HA는 의도만 전달. unique_id는 컴포넌트가 원래 값(클라이언트 네임스페이스 제거)으로 보냄.
 
+### ⬆️ `remove` — 엔티티/디바이스 삭제
+```jsonc
+{ "id": <n>, "type": "ws_bridge/remove", "device_id": "jaalee_jht" }
+```
+`unique_id`만 지정해 단일 엔티티를 지울 수도 있다. `device_id`는 해당 클라이언트
+디바이스와 그 하위 엔티티를 제거한다.
+
+**삭제 범위 (`mode`, 선택)**
+
+| mode | 동작 |
+|------|------|
+| `exact` (기본) | `device_id` / `unique_id`와 **완전 일치**하는 대상만 |
+| `prefix` | 대상 id와 일치하거나 `대상id_`로 시작하는 **하위 id 전부** |
+
+MAC별 `device.id`를 쓰는 advertisement 프로필(`instance_mode: mac`, 고정 MAC 없음)을
+앱에서 삭제할 때는 `mode: "prefix"`를 보낸다. 예: 프로필 `jaalee_jht` 삭제 시
+`jaalee_jht_AABBCCDDEEFF` 인스턴스 디바이스·엔티티까지 함께 제거.
+
+```jsonc
+{ "id": <n>, "type": "ws_bridge/remove",
+  "device_id": "jaalee_jht",
+  "mode": "prefix" }
+```
+
+> 상세 스키마·응답은 [hass-ws-bridge PROTOCOL.md §3.4](https://github.com/eigger/hass-ws-bridge/blob/main/docs/PROTOCOL.md) 참고.
+
 ## 비고
 
 - 모든 바이트열 표기는 hex 문자열(공백 없음).


### PR DESCRIPTION
….14)

Advertisement profiles with instance_mode=mac now send mode=prefix so Jaalee MAC instance devices are removed from HA; pending removal queue stores the mode for offline deletes.