### PR TITLE
fix: OBD 연결 불가 버그 수정 (v0.3.21)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 49
-        versionName = "0.3.20"
+        versionCode = 50
+        versionName = "0.3.21"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -139,6 +139,17 @@ class BleRuntime(
 
         if (oldConfig == null) {
             // First run: complete initialization
+            // 캐시 파라미터를 return 전에 반드시 업데이트해야 한다.
+            // 업데이트하지 않으면 settingsJob이 apply()를 재호출할 때마다
+            // oldConfig==null로 판단해 startSources()를 반복 호출하고,
+            // 진행 중인 연결 Job이 계속 취소·재시작된다.
+            this.lastConfig = config
+            this.lastEnabled = enabledKeys
+            this.lastBoundDevices = boundDevices
+            this.lastScanMode = scanMode
+            this.lastAutoConnectDisabledIds = autoConnectDisabledIds
+            this.lastUnfilteredScan = unfilteredScan
+
             devices.clear(); filters.clear(); obdIndex.clear(); controls.clear()
             declaredAdvInstances.clear()
             discoveredAdvInstances.clear()

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -389,10 +389,10 @@ class NordicElm327Source(
     private val scope: CoroutineScope,
     private val onLinkStatus: (DeviceLinkStatus) -> Unit = {},
 ) : Elm327Source {
-    private val activeConnections = mutableMapOf<String, ClientBleGatt>()
+    private val activeConnections = java.util.concurrent.ConcurrentHashMap<String, ClientBleGatt>()
     private val deviceMutexes = java.util.concurrent.ConcurrentHashMap<String, Mutex>()
     private val pendingDeferreds = java.util.concurrent.ConcurrentHashMap<String, CompletableDeferred<String>>()
-    private val sessionJobs = mutableMapOf<String, Job>()
+    private val sessionJobs = java.util.concurrent.ConcurrentHashMap<String, Job>()
 
     private data class PollTarget(
         val sensor: SensorConfig,


### PR DESCRIPTION
BleRuntime.apply()에서 첫 번째 호출 시 lastConfig를 업데이트하지 않고 return하여, settingsJob이 apply()를 재호출할 때마다 oldConfig==null로 판단해 startSources()를 반복 호출하는 버그 수정.

이로 인해 진행 중인 연결 Job이 계속 취소·재시작되어 OBD 자동 연결 및
수동 연결(Manual 버튼) 모두 동작하지 않는 증상이 발생했음.

Changes:
- BleRuntime.apply(): return 전에 lastConfig, lastEnabled, lastBoundDevices, lastScanMode, lastAutoConnectDisabledIds, lastUnfilteredScan 모두 업데이트
- NordicElm327Source: activeConnections, sessionJobs를 ConcurrentHashMap으로 교체하여 thread-safety 확보
- versionCode: 49 → 50 / versionName: 0.3.20 → 0.3.21