### PR TITLE
fix: localize hardcoded log and preset error strings

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/HassBleApp.kt
+++ b/app/src/main/java/dev/eigger/hassble/HassBleApp.kt
@@ -1,7 +1,12 @@
 package dev.eigger.hassble
 
 import android.app.Application
+import dev.eigger.hassble.service.LiveEventLogger
 
 class HassBleApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        LiveEventLogger.init(this)
+    }
     // TODO: DI 컨테이너 / 싱글톤(ConfigRepository, MqttTransport, ObdPresetStore) 초기화
 }

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -38,6 +38,7 @@ import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanMode
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleScannerSettings
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanFilter
 import dev.eigger.hassble.config.BleScanModeOption
+import dev.eigger.hassble.R
 import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
 import java.util.UUID
@@ -274,7 +275,7 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                 serviceUuidsCache.remove(addr)
                 cacheTimestamps.remove(addr)
             }
-            LiveEventLogger.log(LogType.LINK, "BLE 캐시 정리 완료: ${expiredAddresses.size}개 기기 정보 만료됨")
+            LiveEventLogger.logRes(LogType.LINK, R.string.log_ble_cache_expired, expiredAddresses.size)
         }
     }
 

--- a/app/src/main/java/dev/eigger/hassble/config/ObdPresetStore.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ObdPresetStore.kt
@@ -4,6 +4,10 @@ import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/** [ObdPresetStore]에서 알 수 없는 `preset:` 참조를 만났을 때. */
+class UnknownObdPresetException(val preset: String) :
+    IllegalArgumentException("Unknown preset: $preset")
+
 /**
  * 내장 OBD preset DB (assets/obd_presets.yaml). git 설정의 `preset:` 참조를
  * mode/pid/formula/단위로 펼친다. ESPHome ble_elm327 preset과 동일 개념.
@@ -24,7 +28,7 @@ class ObdPresetStore(private val presets: Map<String, ObdPreset>) {
         expand(GatewayConfig(devices = listOf(device))).devices.first()
 
     private fun expandSensor(s: SensorConfig): SensorConfig {
-        val p = s.preset?.let { presets[it] ?: error("알 수 없는 preset: $it") } ?: return s
+        val p = s.preset?.let { presets[it] ?: throw UnknownObdPresetException(it) } ?: return s
         return s.copy(
             mode = if (s.pid == null) p.mode else s.mode,
             pid = s.pid ?: p.pid,

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import dev.eigger.hassble.BuildConfig
+import dev.eigger.hassble.R
 import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
 import kotlinx.coroutines.withTimeoutOrNull
@@ -320,10 +321,10 @@ class HaWsClient(
                 "auth_ok" -> subscribe()
                 "auth_invalid" -> {
                     if (refreshToken.isNullOrBlank()) {
-                        LiveEventLogger.log(LogType.LINK, "[OAuth] 인증 실패: 리프레시 토큰이 없습니다. 수동 입력 토큰이 무효합니다.")
+                        LiveEventLogger.logRes(LogType.LINK, R.string.log_oauth_auth_failed_no_refresh)
                         handleAuthFailed(webSocket)
                     } else {
-                        LiveEventLogger.log(LogType.LINK, "[OAuth] 엑세스 토큰 만료 감지, 자동 갱신을 시도합니다.")
+                        LiveEventLogger.logRes(LogType.LINK, R.string.log_oauth_token_expired_refreshing)
                         scope.launch(Dispatchers.IO) {
                             val result = HaAuthHelper.refreshAccessToken(baseUrl, refreshToken)
                             if (result.isSuccess) {
@@ -331,10 +332,14 @@ class HaWsClient(
                                 token = newToken
                                 onTokenRefreshed?.invoke(newToken)
                                 reconnectDelayMs = 500L
-                                LiveEventLogger.log(LogType.LINK, "[OAuth] 토큰 자동 갱신 성공 (수명 30분 연장)")
+                                LiveEventLogger.logRes(LogType.LINK, R.string.log_oauth_refresh_success)
                                 webSocket.close(4000, "Token refreshed, reconnecting")
                             } else {
-                                LiveEventLogger.log(LogType.LINK, "[OAuth] 토큰 자동 갱신 실패: ${result.exceptionOrNull()?.localizedMessage}")
+                                LiveEventLogger.logRes(
+                                    LogType.LINK,
+                                    R.string.log_oauth_refresh_failed,
+                                    result.exceptionOrNull()?.localizedMessage ?: "",
+                                )
                                 handleAuthFailed(webSocket)
                             }
                         }

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -290,7 +290,11 @@ class BleGatewayService : Service() {
                 val removalModes = removedIds.associateWith { haRemoveModeFor(it) }
                 repository.queueHaEntityRemoval(removedIds, removalModes)
                 pendingEntityCleanupDeviceIds = pendingEntityCleanupDeviceIds + removedIds
-                LiveEventLogger.log(LogType.LINK, "Config 변경: 삭제된 기기 HA 정리 중 (${removedIds.joinToString()})")
+                LiveEventLogger.logRes(
+                    LogType.LINK,
+                    R.string.log_config_removed_devices_cleanup,
+                    removedIds.joinToString(),
+                )
                 removedIds.forEach { deviceId ->
                     runCatching { ws?.removeDevice(deviceId, removalModes.getValue(deviceId)) }
                     repository.unbindDevice(deviceId)

--- a/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
@@ -1,5 +1,7 @@
 package dev.eigger.hassble.service
 
+import android.content.Context
+import androidx.annotation.StringRes
 import dev.eigger.hassble.config.HassBleDefaults
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -28,6 +30,22 @@ data class LogEntry(
 object LiveEventLogger {
     val BUFFER_LIMIT_OPTIONS = HassBleDefaults.LOG_BUFFER_LIMIT_OPTIONS
     const val DEFAULT_MAX_LOGS = HassBleDefaults.DEFAULT_LOG_BUFFER_LIMIT
+
+    @Volatile
+    private var appContext: Context? = null
+
+    fun init(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun logRes(type: LogType, @StringRes resId: Int, vararg formatArgs: Any?) {
+        val ctx = appContext
+        if (ctx == null) {
+            log(type, "[$resId]")
+            return
+        }
+        log(type, ctx.getString(resId, *formatArgs))
+    }
 
     @Volatile
     var maxLogs: Int = DEFAULT_MAX_LOGS

--- a/app/src/main/java/dev/eigger/hassble/ui/ConfigErrorMapper.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/ConfigErrorMapper.kt
@@ -3,6 +3,7 @@ package dev.eigger.hassble.ui
 import android.content.Context
 import com.charleskorn.kaml.YamlException
 import dev.eigger.hassble.R
+import dev.eigger.hassble.config.UnknownObdPresetException
 import kotlinx.serialization.SerializationException
 import java.io.IOException
 import java.net.ConnectException
@@ -11,6 +12,7 @@ import java.net.UnknownHostException
 object ConfigErrorMapper {
     fun message(context: Context, exception: Throwable?): String {
         return when (exception) {
+            is UnknownObdPresetException -> context.getString(R.string.config_err_unknown_preset, exception.preset)
             is UnknownHostException -> context.getString(R.string.config_err_unknown_host)
             is ConnectException -> context.getString(R.string.config_err_connect)
             is IOException -> context.getString(R.string.config_err_io)

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -768,7 +768,7 @@ private fun HomeScreen() {
                     }.onFailure { e ->
                         Toast.makeText(
                             context,
-                            context.getString(R.string.config_import_failed, e.message ?: template.name),
+                            context.getString(R.string.config_import_failed, ConfigErrorMapper.message(context, e)),
                             Toast.LENGTH_LONG,
                         ).show()
                     }
@@ -802,7 +802,7 @@ private fun HomeScreen() {
                     }.onFailure { e ->
                         Toast.makeText(
                             context,
-                            context.getString(R.string.config_import_failed, e.message ?: device.name),
+                            context.getString(R.string.config_import_failed, ConfigErrorMapper.message(context, e)),
                             Toast.LENGTH_LONG,
                         ).show()
                     }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -112,6 +112,7 @@
     <string name="config_err_yaml">YAML 구문 오류.\n(%1$s)</string>
     <string name="config_err_parse">설정 분석 오류.\n(%1$s)</string>
     <string name="config_err_generic">설정을 불러올 수 없습니다.\n(%1$s)</string>
+    <string name="config_err_unknown_preset">알 수 없는 OBD preset: %1$s</string>
     <string name="config_cache_banner">캐시된 설정을 사용 중입니다. 최신 설정 불러오기에 실패했습니다.</string>
     <string name="config_cache_toast">캐시된 설정을 사용합니다.</string>
     <string name="service_config_load_failed">설정 로드 실패. 등록된 기기가 없습니다.</string>
@@ -174,6 +175,12 @@
     <string name="logs_scroll_to_latest">최신으로 이동</string>
     <string name="logs_empty_gateway_stopped">아직 로그가 없습니다. 게이트웨이를 시작하면 이벤트가 기록됩니다.</string>
     <string name="logs_type_filter">유형</string>
+    <string name="log_ble_cache_expired">BLE 캐시 정리 완료: %1$d개 기기 정보 만료됨</string>
+    <string name="log_config_removed_devices_cleanup">Config 변경: 삭제된 기기 HA 정리 중 (%1$s)</string>
+    <string name="log_oauth_auth_failed_no_refresh">[OAuth] 인증 실패: 리프레시 토큰이 없습니다. 수동 입력 토큰이 무효합니다.</string>
+    <string name="log_oauth_token_expired_refreshing">[OAuth] 액세스 토큰 만료 감지, 자동 갱신을 시도합니다.</string>
+    <string name="log_oauth_refresh_success">[OAuth] 토큰 자동 갱신 성공 (수명 30분 연장)</string>
+    <string name="log_oauth_refresh_failed">[OAuth] 토큰 자동 갱신 실패: %1$s</string>
     <string name="oauth_login_btn">HA OAuth 로그인</string>
     <string name="ha_url_required_toast">HA URL을 먼저 입력해주세요.</string>
     <string name="oauth_fetching_token_toast">HA 토큰을 발급받는 중...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="config_err_yaml">YAML syntax error.\n(%1$s)</string>
     <string name="config_err_parse">Config parse error.\n(%1$s)</string>
     <string name="config_err_generic">Cannot load config.\n(%1$s)</string>
+    <string name="config_err_unknown_preset">Unknown OBD preset: %1$s</string>
     <string name="config_cache_banner">Using cached config. Latest fetch failed.</string>
     <string name="config_cache_toast">Using cached config.</string>
     <string name="service_config_load_failed">Config load failed. Gateway has no devices.</string>
@@ -181,6 +182,12 @@
     <string name="logs_scroll_to_latest">Jump to latest</string>
     <string name="logs_empty_gateway_stopped">No logs yet. Start the gateway to collect events.</string>
     <string name="logs_type_filter">Type</string>
+    <string name="log_ble_cache_expired">BLE cache cleared: %1$d device entries expired</string>
+    <string name="log_config_removed_devices_cleanup">Config changed: cleaning up removed devices in HA (%1$s)</string>
+    <string name="log_oauth_auth_failed_no_refresh">[OAuth] Auth failed: no refresh token. Manual token is invalid.</string>
+    <string name="log_oauth_token_expired_refreshing">[OAuth] Access token expired, attempting automatic refresh.</string>
+    <string name="log_oauth_refresh_success">[OAuth] Token refreshed successfully (extended by 30 minutes).</string>
+    <string name="log_oauth_refresh_failed">[OAuth] Token refresh failed: %1$s</string>
     <string name="oauth_login_btn">HA OAuth Login</string>
     <string name="ha_url_required_toast">Please enter HA URL first.</string>
     <string name="oauth_fetching_token_toast">Fetching HA tokens...</string>


### PR DESCRIPTION
Move LiveEventLogger and OBD preset error messages into string resources with logRes() and ConfigErrorMapper so they follow the device locale.