### PR TITLE
fix: share BLE scan throttle guard with OBD reconnect, improve UX saf…

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -71,6 +71,33 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
     private val serviceUuidsCache = mutableMapOf<String, List<android.os.ParcelUuid>>()
     private val cacheTimestamps = mutableMapOf<String, Long>()
 
+    // Shared throttle guard: Android counts scan starts per-app across ALL scan sessions
+    // (scan() for advertisement devices, scanForMac() for OBD reconnect-wait), not per callback.
+    // A single tracker here ensures both paths respect the same 5-starts-per-30s system limit.
+    private val scanStartTimesMutex = Mutex()
+    private val scanStartTimes = ArrayDeque<Long>()
+
+    private suspend fun awaitScanThrottleSlot() {
+        scanStartTimesMutex.withLock {
+            val now = System.currentTimeMillis()
+            while (scanStartTimes.isNotEmpty() && now - scanStartTimes.first() >= 30_000L) {
+                scanStartTimes.removeFirst()
+            }
+            if (scanStartTimes.size >= 4) {
+                val waitMs = (scanStartTimes.first() + 30_000L) - System.currentTimeMillis() + 100L
+                if (waitMs > 0) {
+                    LiveEventLogger.log(LogType.LINK, "BLE scan throttle guard: waiting ${waitMs}ms")
+                    delay(waitMs)
+                }
+                val after = System.currentTimeMillis()
+                while (scanStartTimes.isNotEmpty() && after - scanStartTimes.first() >= 30_000L) {
+                    scanStartTimes.removeFirst()
+                }
+            }
+            scanStartTimes.addLast(System.currentTimeMillis())
+        }
+    }
+
     private fun getShortUuid(uuid: java.util.UUID): String {
         val s = uuid.toString().uppercase()
         return if (s.endsWith("-0000-1000-8000-00805F9B34FB")) {
@@ -107,29 +134,8 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
         val scanFilters = if (unfiltered) emptyList() else buildScanFilters(devices)
         LiveEventLogger.log(LogType.LINK, "BLE scan mode: ${scanMode.label}, filters: ${scanFilters.size}")
 
-        // Sliding-window throttle guard: Android throttles if ≥5 scans start within 30s.
-        // Track start timestamps and delay only when the next start would hit the limit.
-        val scanStartTimes = ArrayDeque<Long>()
-
         while (currentCoroutineContext().isActive) {
-            // Drop entries outside the 30-second window
-            val now = System.currentTimeMillis()
-            while (scanStartTimes.isNotEmpty() && now - scanStartTimes.first() >= 30_000L) {
-                scanStartTimes.removeFirst()
-            }
-            // If 4 starts already recorded, the next would be the 5th — wait until oldest clears
-            if (scanStartTimes.size >= 4) {
-                val waitMs = (scanStartTimes.first() + 30_000L) - System.currentTimeMillis() + 100L
-                if (waitMs > 0) {
-                    LiveEventLogger.log(LogType.LINK, "BLE scan throttle guard: waiting ${waitMs}ms")
-                    delay(waitMs)
-                }
-                val after = System.currentTimeMillis()
-                while (scanStartTimes.isNotEmpty() && after - scanStartTimes.first() >= 30_000L) {
-                    scanStartTimes.removeFirst()
-                }
-            }
-            scanStartTimes.addLast(System.currentTimeMillis())
+            awaitScanThrottleSlot()
 
             try {
                 scanner.scan(filters = scanFilters, settings = scanSettings).collect { result ->
@@ -282,6 +288,7 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
         }
         val filters = listOf(BleScanFilter(deviceAddress = normalizedMac))
         val scanner = this@NordicAdvertisementScanner.scanner
+        awaitScanThrottleSlot()
         scanner.scan(filters = filters, settings = BleScannerSettings(scanMode = nativeScanMode, legacy = true)).collect { result ->
             val addr = result.device.address?.uppercase()?.replace("-", ":") ?: return@collect
             if (addr == normalizedMac) emit(Unit)

--- a/app/src/main/java/dev/eigger/hassble/ui/AdvertisementWizardDialog.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/AdvertisementWizardDialog.kt
@@ -593,7 +593,7 @@ private fun AdvEditStep(
             OutlinedTextField(
                 value = offset.toString(),
                 onValueChange = { offset = it.toIntOrNull()?.coerceAtLeast(0) ?: 0 },
-                label = { Text("offset") },
+                label = { Text(stringResource(R.string.adv_wizard_offset)) },
                 singleLine = true,
                 modifier = Modifier.weight(1f),
             )
@@ -651,10 +651,15 @@ private fun AdvEditStep(
         }
 
         if (isNumericDecode) {
+            val scaleInvalid = scaleText.isNotBlank() && scaleText.toDoubleOrNull() == null
             OutlinedTextField(
                 value = scaleText,
-                onValueChange = { scaleText = it },
+                onValueChange = { scaleText = filterDecimalInput(it) },
                 label = { Text(stringResource(R.string.adv_wizard_scale)) },
+                isError = scaleInvalid,
+                supportingText = if (scaleInvalid) {
+                    { Text(stringResource(R.string.adv_wizard_scale_invalid), color = MaterialTheme.colorScheme.error) }
+                } else null,
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -899,7 +904,7 @@ internal fun DataTypeDropdown(
             value = selected.name,
             onValueChange = {},
             readOnly = true,
-            label = { Text("type") },
+            label = { Text(stringResource(R.string.adv_wizard_type)) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
             modifier = Modifier.fillMaxWidth().menuAnchor(),
         )
@@ -924,7 +929,7 @@ internal fun EndianDropdown(
             value = selected.name,
             onValueChange = {},
             readOnly = true,
-            label = { Text("endian") },
+            label = { Text(stringResource(R.string.adv_wizard_endian)) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
             modifier = Modifier.fillMaxWidth().menuAnchor(),
         )

--- a/app/src/main/java/dev/eigger/hassble/ui/DeviceEditDialog.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/DeviceEditDialog.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -130,6 +132,7 @@ private fun DecodeEditContent(
 
     val sensors = remember(device.id) { mutableStateListOf<SensorConfig>().apply { addAll(device.sensors) } }
     var editingIndex by remember(device.id) { mutableStateOf<Int?>(null) }
+    var pendingDeleteIndex by remember(device.id) { mutableStateOf<Int?>(null) }
 
     // 센서 입력 폼 상태
     var sensorKey by remember(device.id) { mutableStateOf("value") }
@@ -190,6 +193,38 @@ private fun DecodeEditContent(
 
     val isNumericDecode = dataType !in setOf(DataType.timestamp, DataType.string)
     val decodeLengthEditable = dataType == DataType.string
+
+    pendingDeleteIndex?.let { index ->
+        val target = sensors.getOrNull(index)
+        if (target == null) {
+            pendingDeleteIndex = null
+        } else {
+            Dialog(onDismissRequest = { pendingDeleteIndex = null }) {
+                Card(shape = HassBleShapes.Dialog, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+                    Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Text(stringResource(R.string.device_edit_sensor_delete_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        Text(stringResource(R.string.device_edit_sensor_delete_body, target.key), color = Color.Gray, fontSize = 13.sp)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            HassCancelButton(onClick = { pendingDeleteIndex = null })
+                            Spacer(Modifier.width(8.dp))
+                            HassDangerButton(
+                                text = stringResource(R.string.device_edit_sensor_delete_confirm),
+                                onClick = {
+                                    sensors.removeAt(index)
+                                    if (editingIndex == index) resetForm()
+                                    pendingDeleteIndex = null
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Column(
@@ -277,13 +312,10 @@ private fun DecodeEditContent(
                         color = if (highlighted) MaterialTheme.colorScheme.primary else Color.LightGray,
                     )
                     IconButton(onClick = { loadForm(index) }) {
-                        Icon(Icons.Default.Edit, contentDescription = "Edit", tint = MaterialTheme.colorScheme.primary)
+                        Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.device_edit_btn), tint = MaterialTheme.colorScheme.primary)
                     }
-                    IconButton(onClick = {
-                        sensors.removeAt(index)
-                        if (editingIndex == index) resetForm()
-                    }) {
-                        Icon(Icons.Default.Delete, contentDescription = "Remove", tint = MaterialTheme.colorScheme.error)
+                    IconButton(onClick = { pendingDeleteIndex = index }) {
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.device_edit_sensor_delete_confirm), tint = MaterialTheme.colorScheme.error)
                     }
                 }
             }
@@ -318,7 +350,7 @@ private fun DecodeEditContent(
                 OutlinedTextField(
                     value = offset.toString(),
                     onValueChange = { offset = it.toIntOrNull()?.coerceAtLeast(0) ?: 0 },
-                    label = { Text("offset") },
+                    label = { Text(stringResource(R.string.adv_wizard_offset)) },
                     singleLine = true,
                     modifier = Modifier.weight(1f),
                 )
@@ -388,10 +420,15 @@ private fun DecodeEditContent(
             }
 
             if (isNumericDecode) {
+                val scaleInvalid = scaleText.isNotBlank() && scaleText.toDoubleOrNull() == null
                 OutlinedTextField(
                     value = scaleText,
-                    onValueChange = { scaleText = it },
+                    onValueChange = { scaleText = filterDecimalInput(it) },
                     label = { Text(stringResource(R.string.adv_wizard_scale)) },
+                    isError = scaleInvalid,
+                    supportingText = if (scaleInvalid) {
+                        { Text(stringResource(R.string.adv_wizard_scale_invalid), color = MaterialTheme.colorScheme.error) }
+                    } else null,
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -597,6 +634,20 @@ private fun decodeLengthEditableFor(type: DataType): Boolean = type == DataType.
 
 private fun formatScale(d: Double): String =
     if (d == d.toLong().toDouble()) d.toLong().toString() else d.toString()
+
+/** 숫자 필드용 입력 필터: 숫자, 맨 앞의 '-', 소수점 하나만 허용 (scale은 음수·소수 모두 가능). */
+internal fun filterDecimalInput(raw: String): String {
+    val sb = StringBuilder()
+    var seenDot = false
+    for ((i, ch) in raw.withIndex()) {
+        when {
+            ch == '-' && i == 0 -> sb.append(ch)
+            ch == '.' && !seenDot -> { seenDot = true; sb.append(ch) }
+            ch.isDigit() -> sb.append(ch)
+        }
+    }
+    return sb.toString()
+}
 
 private fun buildSensor(
     base: SensorConfig?,

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -160,6 +160,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -269,7 +270,8 @@ private fun HomeScreen() {
     val enabledSensorsInitialized by repository.enabledSensorsInitialized.collectAsState(initial = false)
     val startOnBoot by repository.startOnBoot.collectAsState(initial = true)
     val scanMode by repository.scanMode.collectAsState(initial = dev.eigger.hassble.config.BleScanModeOption.LOW_LATENCY)
-    val onboardingComplete by repository.onboardingComplete.collectAsState(initial = false)
+    val onboardingCompleteFlow = remember(repository) { repository.onboardingComplete.map<Boolean, Boolean?> { it } }
+    val onboardingComplete by onboardingCompleteFlow.collectAsState(initial = null)
 
     val powerManager = remember { context.getSystemService(Context.POWER_SERVICE) as PowerManager }
     var isBatteryIgnored by remember { mutableStateOf(powerManager.isIgnoringBatteryOptimizations(context.packageName)) }
@@ -391,7 +393,8 @@ private fun HomeScreen() {
     }
 
     LaunchedEffect(onboardingComplete) {
-        if (!onboardingComplete) showOnboarding = true
+        // null: DataStore에서 아직 읽지 못한 초기 상태 — 실제 값 로드 전에는 판단하지 않는다
+        if (onboardingComplete == false) showOnboarding = true
     }
 
     LaunchedEffect(gitUrlInput, gitTokenInput, templatesReloadTrigger) {
@@ -549,6 +552,24 @@ private fun HomeScreen() {
                 text = stringResource(R.string.service_error_banner, err),
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
+        }
+        if (isConfigLoading && selectedTab == 0) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = stringResource(R.string.config_loading_banner),
+                    fontSize = 12.sp,
+                    color = Color.Gray,
+                )
+            }
         }
 
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -755,15 +776,16 @@ private fun HomeScreen() {
                         val unique = ConfigMerger.ensureUniqueId(device, existingIds)
                         repository.addDraftDevice(unique)
                         draftDevices = repository.loadDraftDevices()
-                        unique
+                        device.id to unique
                     }
                     showTemplateDialog = false
-                    result.onSuccess { unique ->
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.config_imported_toast, unique.name),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    result.onSuccess { (requestedId, unique) ->
+                        val toastText = if (unique.id != requestedId) {
+                            context.getString(R.string.config_imported_toast_renamed, unique.name, unique.id)
+                        } else {
+                            context.getString(R.string.config_imported_toast, unique.name)
+                        }
+                        Toast.makeText(context, toastText, Toast.LENGTH_SHORT).show()
                         if (isRunning) BleGatewayService.reloadConfig(context, gitUrlInput, gitTokenInput.ifBlank { null })
                     }.onFailure { e ->
                         Toast.makeText(
@@ -789,15 +811,16 @@ private fun HomeScreen() {
                         val unique = ConfigMerger.ensureUniqueId(expanded, existingIds)
                         repository.addDraftDevice(unique)
                         draftDevices = repository.loadDraftDevices()
-                        unique
+                        expanded.id to unique
                     }
                     showObdDialog = false
-                    result.onSuccess { unique ->
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.config_imported_toast, unique.name),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    result.onSuccess { (requestedId, unique) ->
+                        val toastText = if (unique.id != requestedId) {
+                            context.getString(R.string.config_imported_toast_renamed, unique.name, unique.id)
+                        } else {
+                            context.getString(R.string.config_imported_toast, unique.name)
+                        }
+                        Toast.makeText(context, toastText, Toast.LENGTH_SHORT).show()
                         if (isRunning) BleGatewayService.reloadConfig(context, gitUrlInput, gitTokenInput.ifBlank { null })
                     }.onFailure { e ->
                         Toast.makeText(
@@ -830,11 +853,12 @@ private fun HomeScreen() {
                     repository.addDraftDevice(unique)
                     draftDevices = repository.loadDraftDevices()
                     showAdvWizard = false
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.config_imported_toast, unique.name),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    val toastText = if (unique.id != device.id) {
+                        context.getString(R.string.config_imported_toast_renamed, unique.name, unique.id)
+                    } else {
+                        context.getString(R.string.config_imported_toast, unique.name)
+                    }
+                    Toast.makeText(context, toastText, Toast.LENGTH_SHORT).show()
                     if (isRunning) BleGatewayService.reloadConfig(context, gitUrlInput, gitTokenInput.ifBlank { null })
                 }
             },
@@ -1037,7 +1061,7 @@ private fun GatewayTabContent(
         Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = Icons.Default.Info, contentDescription = "Status", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+                    Icon(imageVector = Icons.Default.Info, contentDescription = stringResource(R.string.cd_status), tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = stringResource(R.string.system_monitor), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                 }
@@ -1064,7 +1088,7 @@ private fun GatewayTabContent(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+                        Icon(imageVector = Icons.Default.Settings, contentDescription = stringResource(R.string.logs_settings), tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(text = stringResource(R.string.server_integration_settings), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                     }
@@ -1137,7 +1161,7 @@ private fun GatewayTabContent(
                         onUrlChange(it)
                         urlError = validateHaUrl(context, it)
                     },
-                    label = { Text("HA URL") },
+                    label = { Text(stringResource(R.string.label_ha_url)) },
                     enabled = inputsEnabled,
                     isError = urlError != null,
                     modifier = Modifier.fillMaxWidth(),
@@ -1264,7 +1288,7 @@ private fun GatewayTabContent(
         Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+                    Icon(imageVector = Icons.Default.Settings, contentDescription = stringResource(R.string.logs_settings), tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = stringResource(R.string.background_battery_settings), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                 }
@@ -1497,7 +1521,7 @@ private fun SensorsTabContent(
                         if (deviceSearchText.isNotEmpty()) {
                             Icon(
                                 imageVector = Icons.Default.Close,
-                                contentDescription = null,
+                                contentDescription = stringResource(R.string.cd_clear),
                                 tint = Color.Gray,
                                 modifier = Modifier
                                     .size(18.dp)
@@ -1602,7 +1626,7 @@ private fun SensorsTabContent(
                 ) {
                     Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(imageVector = Icons.Default.Warning, contentDescription = "Error", tint = MaterialTheme.colorScheme.error)
+                            Icon(imageVector = Icons.Default.Warning, contentDescription = stringResource(R.string.cd_error), tint = MaterialTheme.colorScheme.error)
                             Spacer(modifier = Modifier.width(12.dp))
                             Text(
                                 text = stringResource(R.string.config_load_error, configError),
@@ -1738,6 +1762,30 @@ private fun DeviceConfigCard(
         validationIssues.count { it.level == ValidationLevel.WARNING && it.sensorKey != null }
     }
     var expanded by remember(device.id) { mutableStateOf(false) }
+    var showDeleteConfirm by remember(device.id) { mutableStateOf(false) }
+
+    if (showDeleteConfirm) {
+        Dialog(onDismissRequest = { showDeleteConfirm = false }) {
+            Card(shape = HassBleShapes.Dialog, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+                Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(stringResource(R.string.device_delete_confirm_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                    Text(stringResource(R.string.device_delete_confirm_body), color = Color.Gray, fontSize = 13.sp)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        HassCancelButton(onClick = { showDeleteConfirm = false })
+                        Spacer(Modifier.width(8.dp))
+                        HassDangerButton(
+                            text = stringResource(R.string.device_delete_confirm_button),
+                            onClick = { showDeleteConfirm = false; onDelete() },
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     Card(
         modifier = Modifier
@@ -2210,7 +2258,7 @@ private fun DeviceConfigCard(
                         }
                         HassDangerTintButton(
                             text = stringResource(R.string.device_delete_btn),
-                            onClick = onDelete,
+                            onClick = { showDeleteConfirm = true },
                             enabled = !isConnected,
                         )
                     }
@@ -2517,6 +2565,34 @@ private fun LogsTabContent(
     var settingsExpanded by remember { mutableStateOf(false) }
     var followLatest by remember { mutableStateOf(true) }
     var disabledTypes by remember { mutableStateOf(setOf<LogType>()) }
+    var showClearLogsConfirm by remember { mutableStateOf(false) }
+
+    if (showClearLogsConfirm) {
+        Dialog(onDismissRequest = { showClearLogsConfirm = false }) {
+            Card(shape = HassBleShapes.Dialog, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+                Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(stringResource(R.string.logs_clear_confirm_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                    Text(stringResource(R.string.logs_clear_confirm_body), color = Color.Gray, fontSize = 13.sp)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        HassCancelButton(onClick = { showClearLogsConfirm = false })
+                        Spacer(Modifier.width(8.dp))
+                        HassDangerButton(
+                            text = stringResource(R.string.logs_clear),
+                            onClick = {
+                                showClearLogsConfirm = false
+                                logsList.clear()
+                                LiveEventLogger.clearLogs()
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     LaunchedEffect(logBufferLimit) {
         LiveEventLogger.setMaxLogs(logBufferLimit)
@@ -2661,10 +2737,7 @@ private fun LogsTabContent(
                         )
                         HassLinkButton(
                             text = stringResource(R.string.logs_clear),
-                            onClick = {
-                                logsList.clear()
-                                LiveEventLogger.clearLogs()
-                            },
+                            onClick = { showClearLogsConfirm = true },
                         )
                     }
                 }
@@ -2691,7 +2764,7 @@ private fun LogsTabContent(
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Search,
-                            contentDescription = "Search",
+                            contentDescription = stringResource(R.string.cd_search),
                             tint = Color.Gray,
                             modifier = Modifier.size(16.dp),
                         )
@@ -2700,7 +2773,7 @@ private fun LogsTabContent(
                         if (filterText.isNotEmpty()) {
                             Icon(
                                 imageVector = Icons.Default.Close,
-                                contentDescription = "Clear",
+                                contentDescription = stringResource(R.string.cd_clear),
                                 tint = Color.Gray,
                                 modifier = Modifier
                                     .size(16.dp)

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2,6 +2,11 @@
 <resources>
     <string name="app_name">HassBle</string>
     <string name="app_sub_title">Home Assistant BLE 게이트웨이</string>
+    <string name="cd_status">상태</string>
+    <string name="cd_error">오류</string>
+    <string name="cd_search">검색</string>
+    <string name="cd_clear">지우기</string>
+    <string name="label_ha_url">HA URL</string>
     <string name="system_monitor">시스템 모니터</string>
     <string name="service_running">서비스 작동</string>
     <string name="status_running">실행 중</string>
@@ -114,6 +119,7 @@
     <string name="config_err_generic">설정을 불러올 수 없습니다.\n(%1$s)</string>
     <string name="config_err_unknown_preset">알 수 없는 OBD preset: %1$s</string>
     <string name="config_cache_banner">캐시된 설정을 사용 중입니다. 최신 설정 불러오기에 실패했습니다.</string>
+    <string name="config_loading_banner">최신 설정을 불러오는 중…</string>
     <string name="config_cache_toast">캐시된 설정을 사용합니다.</string>
     <string name="service_config_load_failed">설정 로드 실패. 등록된 기기가 없습니다.</string>
     <string name="service_error_banner">게이트웨이 오류: %1$s</string>
@@ -156,6 +162,8 @@
     <string name="logs_empty_hint">아직 로그가 없습니다.</string>
     <string name="logs_filter_empty">필터와 일치하는 로그가 없습니다.</string>
     <string name="logs_clear">지우기</string>
+    <string name="logs_clear_confirm_title">모든 로그를 지울까요?</string>
+    <string name="logs_clear_confirm_body">현재 버퍼에 있는 모든 로그 항목이 삭제됩니다. 되돌릴 수 없습니다.</string>
     <string name="logs_share">공유</string>
     <string name="logs_save">저장</string>
     <string name="logs_empty">공유할 로그가 없습니다</string>
@@ -231,6 +239,7 @@
     <string name="config_obd_presets_label">OBD preset</string>
     <string name="config_add_device_confirm">추가</string>
     <string name="config_imported_toast">추가됨: %1$s</string>
+    <string name="config_imported_toast_renamed">추가됨: %1$s (ID가 이미 사용 중이라 "%2$s"로 변경됨)</string>
     <string name="config_import_failed">추가 실패: %1$s</string>
     <string name="config_export_failed">보내기 실패: %1$s</string>
     <string name="config_cache_banner_with_time">캐시된 설정 사용 중 (저장: %1$s). 최신 불러오기 실패.</string>
@@ -251,7 +260,11 @@
     <string name="adv_wizard_sensor_key">센서 키</string>
     <string name="adv_wizard_tap_offset">바이트를 탭해 decode offset 지정</string>
     <string name="adv_wizard_no_payload">선택한 필드에 payload 없음</string>
+    <string name="adv_wizard_offset">offset</string>
+    <string name="adv_wizard_type">type</string>
+    <string name="adv_wizard_endian">endian</string>
     <string name="adv_wizard_scale">스케일</string>
+    <string name="adv_wizard_scale_invalid">올바른 숫자를 입력하세요 (예: 0.1, -1)</string>
     <string name="adv_wizard_unit">단위 (선택)</string>
     <string name="adv_wizard_device_class">device_class (선택)</string>
     <string name="adv_wizard_state_class">state_class (선택)</string>
@@ -293,6 +306,9 @@
     <string name="scan_mode_low_latency_btn">고성능</string>
     <string name="auto_connect_label">자동 연결</string>
     <string name="device_delete_btn">삭제</string>
+    <string name="device_delete_confirm_title">이 기기를 삭제할까요?</string>
+    <string name="device_delete_confirm_body">Home Assistant의 관련 엔티티도 함께 삭제됩니다. 되돌릴 수 없습니다.</string>
+    <string name="device_delete_confirm_button">삭제</string>
     <string name="device_edit_btn">편집</string>
     <string name="device_edit_title">기기 편집</string>
     <string name="device_edit_save">변경사항 저장</string>
@@ -301,6 +317,9 @@
     <string name="device_edit_mfr_min_length">manufacturer_min_length</string>
     <string name="device_edit_match_readonly">읽기 전용 매칭 항목 (YAML에서 수정)</string>
     <string name="device_edit_editing_sensor">센서 편집 중</string>
+    <string name="device_edit_sensor_delete_title">이 센서를 삭제할까요?</string>
+    <string name="device_edit_sensor_delete_body">"%1$s" 센서가 이 기기에서 제거됩니다. 되돌릴 수 없습니다.</string>
+    <string name="device_edit_sensor_delete_confirm">삭제</string>
     <string name="device_edit_update_sensor">변경 적용</string>
     <string name="device_edit_cancel_sensor">새로 추가</string>
     <string name="notif_warn_channel_name">HassBle 경고</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,11 @@
 <resources>
     <string name="app_name">HassBle</string>
     <string name="app_sub_title">Home Assistant BLE Gateway</string>
+    <string name="cd_status">Status</string>
+    <string name="cd_error">Error</string>
+    <string name="cd_search">Search</string>
+    <string name="cd_clear">Clear</string>
+    <string name="label_ha_url">HA URL</string>
     <string name="system_monitor">System Monitor</string>
     <string name="service_running">Service Running</string>
     <string name="status_running">Running</string>
@@ -117,6 +122,7 @@
     <string name="config_err_generic">Cannot load config.\n(%1$s)</string>
     <string name="config_err_unknown_preset">Unknown OBD preset: %1$s</string>
     <string name="config_cache_banner">Using cached config. Latest fetch failed.</string>
+    <string name="config_loading_banner">Fetching latest config…</string>
     <string name="config_cache_toast">Using cached config.</string>
     <string name="service_config_load_failed">Config load failed. Gateway has no devices.</string>
     <string name="service_error_banner">Gateway error: %1$s</string>
@@ -163,6 +169,8 @@
     <string name="logs_empty_hint">No logs yet.</string>
     <string name="logs_filter_empty">No logs match the filter.</string>
     <string name="logs_clear">Clear</string>
+    <string name="logs_clear_confirm_title">Clear all logs?</string>
+    <string name="logs_clear_confirm_body">This will remove all currently buffered log entries. This cannot be undone.</string>
     <string name="logs_share">Share</string>
     <string name="logs_save">Save</string>
     <string name="logs_empty">No logs to share</string>
@@ -238,6 +246,7 @@
     <string name="config_obd_presets_label">OBD presets</string>
     <string name="config_add_device_confirm">Add</string>
     <string name="config_imported_toast">Added: %1$s</string>
+    <string name="config_imported_toast_renamed">Added: %1$s (ID already in use — assigned "%2$s" instead)</string>
     <string name="config_import_failed">Failed to add: %1$s</string>
     <string name="config_export_failed">Export failed: %1$s</string>
     <string name="config_cache_banner_with_time">Using cached config (saved %1$s). Latest fetch failed.</string>
@@ -258,7 +267,11 @@
     <string name="adv_wizard_sensor_key">Sensor key</string>
     <string name="adv_wizard_tap_offset">Tap a byte to set decode offset</string>
     <string name="adv_wizard_no_payload">No payload for selected source field</string>
+    <string name="adv_wizard_offset">offset</string>
+    <string name="adv_wizard_type">type</string>
+    <string name="adv_wizard_endian">endian</string>
     <string name="adv_wizard_scale">Scale</string>
+    <string name="adv_wizard_scale_invalid">Enter a valid number, e.g. 0.1 or -1</string>
     <string name="adv_wizard_unit">Unit (optional)</string>
     <string name="adv_wizard_device_class">device_class (optional)</string>
     <string name="adv_wizard_state_class">state_class (optional)</string>
@@ -300,6 +313,9 @@
     <string name="scan_mode_low_latency_btn">High Performance</string>
     <string name="auto_connect_label">Auto Connect</string>
     <string name="device_delete_btn">Delete</string>
+    <string name="device_delete_confirm_title">Delete this device?</string>
+    <string name="device_delete_confirm_body">This will also remove its entities from Home Assistant. This cannot be undone.</string>
+    <string name="device_delete_confirm_button">Delete</string>
     <string name="device_edit_btn">Edit</string>
     <string name="device_edit_title">Edit device</string>
     <string name="device_edit_save">Save changes</string>
@@ -308,6 +324,9 @@
     <string name="device_edit_mfr_min_length">manufacturer_min_length</string>
     <string name="device_edit_match_readonly">Read-only match keys (edit in YAML)</string>
     <string name="device_edit_editing_sensor">Editing sensor</string>
+    <string name="device_edit_sensor_delete_title">Remove this sensor?</string>
+    <string name="device_edit_sensor_delete_body">"%1$s" will be removed from this device. This cannot be undone.</string>
+    <string name="device_edit_sensor_delete_confirm">Remove</string>
     <string name="device_edit_update_sensor">Apply changes</string>
     <string name="device_edit_cancel_sensor">New</string>
     <string name="notif_warn_channel_name">HassBle Warnings</string>


### PR DESCRIPTION
…ety and polish

BLE reliability:
- scanForMac() (OBD reconnect-wait) now shares the same 30s/5-start throttle tracker as scan() (advertisement devices), guarded by a Mutex. Previously each path tracked its own start count, so a flaky OBD dongle reconnecting frequently could push the app's total scan starts over Android's system-wide per-app limit without either path's own counter noticing, silently degrading advertisement scan reliability.

UX safety (destructive actions now require confirmation):
- Device delete (also removes HA entities) — MainActivity.kt
- Per-sensor remove in device editor — DeviceEditDialog.kt
- Clear all logs — MainActivity.kt All three reuse the existing OAuth-clear confirmation dialog pattern.

UX polish:
- Gateway tab now shows a loading indicator while remote config.yaml is being fetched, matching the existing Sensors tab behavior.
- scale field in sensor decode forms now filters to valid numeric input and shows an inline error instead of silently defaulting to 1.0 on invalid input (DeviceEditDialog + AdvertisementWizardDialog).
- Device-add success toast now shows the actual assigned ID when a duplicate ID gets auto-renamed, instead of only showing the name.
- Replaced hardcoded English content-description/label strings with localized string resources (Status, Error, Search, Clear, HA URL, offset/type/endian field labels); fixed one interactive icon (sensor search clear button) that had no accessibility label at all.