### PR TITLE
feat(obd): support multi-sensor PIDs, bytes a–t, and header restore

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
@@ -69,5 +69,33 @@ interface Elm327Source {
     companion object {
         /** 매 연결 시 항상 먼저 보내는 base 시퀀스 (ESPHome ble_elm327과 동일). */
         val BASE_INIT = listOf("ATZ", "ATE0", "ATL0", "ATS0", "ATH0", "ATSP0")
+
+        /** ELM327이 11bit CAN에서 쓰는 기본 전송 헤더 (기능 주소 브로드캐스트). */
+        const val DEFAULT_CAN_HEADER = "ATSH7DF"
+
+        /** `ATSH…` / `AT SH …` 처럼 전송 헤더를 바꾸는 명령인지. */
+        fun isSetHeader(cmd: String): Boolean =
+            cmd.filter { !it.isWhitespace() }.lowercase().startsWith("atsh")
+
+        /**
+         * `pre_commands`가 없는 센서를 폴링하기 직전에 보낼 헤더 복원 명령.
+         *
+         * 헤더를 바꾸는 센서가 하나라도 있으면, 그 뒤에 오는 표준 센서가 남은 헤더를
+         * 물려받아 엉뚱한 ECU로 요청이 나간다. 이를 되돌리기 위한 baseline을 고른다.
+         * 우선순위는 `default_commands` → `init_commands`의 마지막 `ATSH` → CAN 기본 헤더.
+         *
+         * 헤더를 바꾸는 센서가 없으면 빈 목록을 돌려준다. 복원할 것이 없을 뿐 아니라,
+         * K-line(ISO 9141/KWP)처럼 헤더 형식이 다른 프로토콜에 `ATSH7DF`를 밀어넣으면
+         * 오히려 통신이 깨지기 때문이다.
+         */
+        fun resolveHeaderRestore(
+            defaultCommands: List<String>,
+            initCommands: List<String>,
+            sensorPreCommands: List<List<String>>,
+        ): List<String> = when {
+            defaultCommands.isNotEmpty() -> defaultCommands
+            sensorPreCommands.none { it.any(::isSetHeader) } -> emptyList()
+            else -> listOf(initCommands.lastOrNull(::isSetHeader) ?: DEFAULT_CAN_HEADER)
+        }
     }
 }

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -76,7 +76,8 @@ class BleRuntime(
 
     private val devices = java.util.concurrent.ConcurrentHashMap<String, DeviceConfig>()
     private val filters = java.util.concurrent.ConcurrentHashMap<String, ValueFilter>()  // uniqueId → filter
-    private val obdIndex = java.util.concurrent.ConcurrentHashMap<String, Map<Pair<String, String>, SensorConfig>>()
+    // mode+pid 하나에 센서 여러 개가 붙을 수 있다 (예: 현대 22B002 → 오도미터·연료·전압)
+    private val obdIndex = java.util.concurrent.ConcurrentHashMap<String, Map<Pair<String, String>, List<SensorConfig>>>()
     private val controls = java.util.concurrent.ConcurrentHashMap<String, Pair<DeviceConfig, ControlConfig>>()  // uniqueId →
     private val declaredAdvInstances = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
     private val discoveredAdvInstances = java.util.concurrent.ConcurrentHashMap<String, DiscoveredAdvInstance>()
@@ -360,7 +361,7 @@ class BleRuntime(
         if (d.source == Source.obd) {
             val errKeys = ConfigValidator.errorKeys(validationIssues, d.id)
             obdIndex[d.id] = d.sensors.filter { it.pid != null && it.key !in errKeys }
-                .associateBy { it.mode to it.pid!!.uppercase() }
+                .groupBy { it.mode to it.pid!!.uppercase() }
         }
         declareAndPrepare(d)
 
@@ -504,10 +505,16 @@ class BleRuntime(
             }
             Source.obd -> {
                 val (mode, pid, data) = Decoder.parseObdResponse(r.rawHex) ?: return
-                val s = obdIndex[d.id]?.get(mode to pid) ?: return
-                if (!isEnabled(d.id, s.key) || s.formula == null) return
-                onLinkDataReceived(d.id, System.currentTimeMillis())
-                emit(d, d.id, s, runCatching { Decoder.evalFormula(s.formula, data) }.getOrNull(), out)
+                val sensors = obdIndex[d.id]?.get(mode to pid) ?: return
+                var matched = false
+                for (s in sensors) {
+                    if (!isEnabled(d.id, s.key) || s.formula == null) continue
+                    if (!matched) {
+                        onLinkDataReceived(d.id, System.currentTimeMillis())
+                        matched = true
+                    }
+                    emit(d, d.id, s, runCatching { Decoder.evalFormula(s.formula, data) }.getOrNull(), out)
+                }
             }
             Source.gatt_notify -> {
                 val bytes = Decoder.hexToBytes(r.rawHex) ?: return

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -608,6 +608,13 @@ class NordicElm327Source(
                 if (!isDuplicateInit(cmd)) txQueue.add(TxItem(cmd))
             }
 
+            // 헤더를 바꾸는 센서 뒤에 오는 표준 센서를 위해 되돌릴 명령. 없으면 빈 목록.
+            val headerRestore = Elm327Source.resolveHeaderRestore(
+                defaultCommands = obd.defaultCommands,
+                initCommands = obd.initCommands,
+                sensorPreCommands = targets.map { it.sensor.preCommands },
+            )
+
             var elmReady = false
             var currentPreCommands: List<String> = emptyList()
             var lastTxAtMs = 0L
@@ -653,9 +660,10 @@ class NordicElm327Source(
                             val target = targets[(collectIdx + i) % n]
                             if (now >= target.nextPollAtMs) {
                                 val sensor = target.sensor
-                                if (sensor.preCommands != currentPreCommands) {
-                                    sensor.preCommands.forEach { txQueue.add(TxItem(it)) }
-                                    currentPreCommands = sensor.preCommands
+                                val pre = sensor.preCommands.ifEmpty { headerRestore }
+                                if (pre != currentPreCommands) {
+                                    pre.forEach { txQueue.add(TxItem(it)) }
+                                    currentPreCommands = pre
                                 }
                                 txQueue.add(TxItem("${sensor.mode}${sensor.pid}", target))
                                 target.nextPollAtMs = now + parseDurationMs(sensor.updateInterval, 60_000L)

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -68,6 +68,9 @@ data class ObdConfig(
     @SerialName("rx_char_uuid") val rxCharUuid: String = "FFF1",
     @SerialName("tx_delay") val txDelay: String = "50ms",
     @SerialName("init_commands") val initCommands: List<String> = emptyList(),
+    // pre_commands가 없는 센서를 폴링하기 직전에 보낼 명령 (예: ["ATSH7E0"]).
+    // 헤더를 바꾸는 센서가 남긴 상태를 되돌리는 용도. 비우면 종전대로 마지막 헤더가 유지된다.
+    @SerialName("default_commands") val defaultCommands: List<String> = emptyList(),
     @SerialName("auto_connect") val autoConnect: Boolean = true,
 )
 

--- a/app/src/main/java/dev/eigger/hassble/decode/Decoder.kt
+++ b/app/src/main/java/dev/eigger/hassble/decode/Decoder.kt
@@ -9,7 +9,7 @@ import java.util.Calendar
 /**
  * 바이트 → 값 디코더 (앱 측). 광고/notify/OBD 공유.
  *  - decodeStructured : offset/length/type/endian/scale/map (광고/notify)
- *  - evalFormula      : 응답 바이트 a,b,c,d... 식 (OBD)
+ *  - evalFormula      : 응답 바이트 a~t (0~19번째) 식 (OBD)
  *  - parseObdResponse : ELM327 응답 hex → (mode, pid, dataBytes)
  */
 object Decoder {
@@ -32,11 +32,25 @@ object Decoder {
         }
     }
 
+    /** formula에서 응답 바이트를 가리키는 변수명. a=0번째 … t=19번째 바이트. */
+    private const val BYTE_NAMES = "abcdefghijklmnopqrst"
+
+    private val IDENTIFIER = Regex("[a-zA-Z_]+")
+
     fun evalFormula(formula: String, data: ByteArray): Double {
-        val names = "abcdefgh"
         val vars = buildMap {
-            for (i in data.indices.take(names.length)) {
-                put(names[i].toString(), (data[i].toInt() and 0xFF).toDouble())
+            for (i in data.indices.take(BYTE_NAMES.length)) {
+                put(BYTE_NAMES[i].toString(), (data[i].toInt() and 0xFF).toDouble())
+            }
+        }
+        // exp4j는 e/pi/π/φ를 내장 상수로 등록한다. 응답이 짧아 'e'가 바인딩되지 않으면
+        // 오일러 상수 2.718로 조용히 평가되므로, 미바인딩 바이트 변수는 명시적으로 거른다.
+        for (m in IDENTIFIER.findAll(formula)) {
+            val name = m.value
+            if (name.length == 1 && name[0] in BYTE_NAMES && name !in vars) {
+                throw IllegalArgumentException(
+                    "formula '$formula' needs byte '$name' but response has only ${data.size} byte(s)",
+                )
             }
         }
         return ExpressionBuilder(formula).variables(vars.keys).build().setVariables(vars).evaluate()

--- a/app/src/test/java/dev/eigger/hassble/ble/HeaderRestoreTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/HeaderRestoreTest.kt
@@ -1,0 +1,67 @@
+package dev.eigger.hassble.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HeaderRestoreTest {
+
+    private fun resolve(
+        defaultCommands: List<String> = emptyList(),
+        initCommands: List<String> = emptyList(),
+        sensorPreCommands: List<List<String>> = emptyList(),
+    ) = Elm327Source.resolveHeaderRestore(defaultCommands, initCommands, sensorPreCommands)
+
+    @Test
+    fun `no header switching sensors leaves behaviour untouched`() {
+        // K-line 등에서 ATSH7DF를 밀어넣으면 안 되므로 빈 목록이어야 한다.
+        val restore = resolve(
+            initCommands = listOf("ATSP0"),
+            sensorPreCommands = listOf(emptyList(), emptyList()),
+        )
+        assertTrue(restore.isEmpty())
+    }
+
+    @Test
+    fun `header switching sensor triggers can default restore`() {
+        val restore = resolve(
+            initCommands = listOf("ATSP6"),
+            sensorPreCommands = listOf(listOf("ATSH7C6"), emptyList()),
+        )
+        assertEquals(listOf("ATSH7DF"), restore)
+    }
+
+    @Test
+    fun `init header wins over can default`() {
+        val restore = resolve(
+            initCommands = listOf("ATSP6", "ATSH7E0"),
+            sensorPreCommands = listOf(listOf("ATSH7C6"), emptyList()),
+        )
+        assertEquals(listOf("ATSH7E0"), restore)
+    }
+
+    @Test
+    fun `explicit default_commands wins over everything`() {
+        val restore = resolve(
+            defaultCommands = listOf("ATSH7E0", "ATCRA7E8"),
+            initCommands = listOf("ATSH7DF"),
+            sensorPreCommands = listOf(emptyList()),
+        )
+        assertEquals(listOf("ATSH7E0", "ATCRA7E8"), restore)
+    }
+
+    @Test
+    fun `non header pre_commands do not trigger restore`() {
+        val restore = resolve(sensorPreCommands = listOf(listOf("ATFCSD300000")))
+        assertTrue(restore.isEmpty())
+    }
+
+    @Test
+    fun `isSetHeader tolerates spacing and case`() {
+        assertTrue(Elm327Source.isSetHeader("ATSH7C6"))
+        assertTrue(Elm327Source.isSetHeader("at sh 7C6"))
+        assertFalse(Elm327Source.isSetHeader("ATSP6"))
+        assertFalse(Elm327Source.isSetHeader("ATFCSH7C6"))
+    }
+}

--- a/app/src/test/java/dev/eigger/hassble/decode/EvalFormulaTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/EvalFormulaTest.kt
@@ -1,0 +1,57 @@
+package dev.eigger.hassble.decode
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class EvalFormulaTest {
+
+    private fun bytes(vararg v: Int) = ByteArray(v.size) { v[it].toByte() }
+
+    @Test
+    fun `standard rpm formula`() {
+        // 01 0C → 1A F8 = 6904 / 4 = 1726 rpm
+        assertEquals(1726.0, Decoder.evalFormula("(a*256+b)/4", bytes(0x1A, 0xF8)), 0.001)
+    }
+
+    @Test
+    fun `bytes beyond h are addressable`() {
+        // 현대 계기판 22B002: g:h:i 24비트 오도미터
+        val data = bytes(0x00, 0x00, 0x00, 0x00, 0x5A, 0x9C, 0x01, 0xE2, 0x40)
+        assertEquals(123456.0, Decoder.evalFormula("g*65536+h*256+i", data), 0.001)
+    }
+
+    @Test
+    fun `byte t is the last addressable variable`() {
+        val data = ByteArray(20) { it.toByte() }
+        assertEquals(19.0, Decoder.evalFormula("t", data), 0.001)
+    }
+
+    @Test
+    fun `fuel level uses byte e`() {
+        // 22B002 byte E * 0.5 = liters
+        val data = bytes(0x00, 0x00, 0x00, 0x00, 0x5A)
+        assertEquals(45.0, Decoder.evalFormula("e*0.5", data), 0.001)
+    }
+
+    @Test
+    fun `unbound e is rejected instead of resolving to euler constant`() {
+        // exp4j는 e를 내장 상수로 등록하므로, 가드가 없으면 2.718*0.5로 조용히 계산된다.
+        val short = bytes(0x01, 0x02, 0x03, 0x04)
+        assertThrows(IllegalArgumentException::class.java) {
+            Decoder.evalFormula("e*0.5", short)
+        }
+    }
+
+    @Test
+    fun `unbound byte variable is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Decoder.evalFormula("g*65536+h*256+i", bytes(0x01, 0x02))
+        }
+    }
+
+    @Test
+    fun `function names are not mistaken for byte variables`() {
+        assertEquals(2.0, Decoder.evalFormula("sqrt(a)", bytes(0x04)), 0.001)
+    }
+}


### PR DESCRIPTION
Reading the Hyundai/Kia cluster (ATSH7C6 + 22B002) needs three things the OBD path could not do. That single response carries odometer, fuel level and cluster voltage at bytes g:h:i, e and f respectively.

- Decoder.evalFormula: expose response bytes as a–t (0–19) instead of a–h. exp4j registers e/pi/π/φ as built-in constants, so an unbound `e` used to evaluate silently as Euler's number (2.718) instead of failing. Reject any byte variable the response is too short to bind, so the poll publishes nothing rather than a plausible-looking wrong value.

- BleRuntime.obdIndex: group sensors by (mode, pid) instead of associateBy. Several sensors can share one PID; the map previously kept only the last one and silently dropped the rest.

- Elm327Source.resolveHeaderRestore: an ELM327 transmit header stays in effect once set, so a sensor with pre_commands ["ATSH7C6"] left standard mode 01 requests pointing at the cluster, which answers NO DATA. When any sensor switches the header, restore it before sensors that declare none — using obd.default_commands, else the last ATSH in init_commands, else the CAN default ATSH7DF. Devices that never switch headers send nothing extra, so K-line protocols are not handed a CAN-shaped header.