### PR TITLE
feat(obd): let OBD sensors extract values by byte offset

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -508,12 +508,22 @@ class BleRuntime(
                 val sensors = obdIndex[d.id]?.get(mode to pid) ?: return
                 var matched = false
                 for (s in sensors) {
-                    if (!isEnabled(d.id, s.key) || s.formula == null) continue
+                    if (!isEnabled(d.id, s.key)) continue
+                    if (s.decode == null && s.formula == null) continue
                     if (!matched) {
                         onLinkDataReceived(d.id, System.currentTimeMillis())
                         matched = true
                     }
-                    emit(d, d.id, s, runCatching { Decoder.evalFormula(s.formula, data) }.getOrNull(), out)
+                    // decode가 있으면 우선한다. formula 변수는 응답의 앞 20바이트까지만
+                    // 가리킬 수 있어서, 그 뒤에 있는 값은 offset으로만 읽을 수 있다.
+                    // 응답이 짧아 범위를 벗어나면 decodeStructured가 null을 주고,
+                    // emit이 그것을 버리므로 그 주기에는 아무것도 발행되지 않는다.
+                    val value = if (s.decode != null) {
+                        Decoder.decodeStructured(data, s.decode)
+                    } else {
+                        runCatching { Decoder.evalFormula(s.formula!!, data) }.getOrNull()
+                    }
+                    emit(d, d.id, s, value, out)
                 }
             }
             Source.gatt_notify -> {

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -118,6 +118,13 @@ object ConfigValidator {
                     "OBD sensor requires 'pid' or 'preset' — sensor will be skipped",
                     sensorPath(id, key, "preset"))
 
+            // OBD 센서는 formula(preset 포함) 또는 decode 중 하나로 값을 뽑는다.
+            // preset은 설정 로딩 시 이미 formula로 펼쳐진 뒤 검증된다.
+            if (device.source == Source.obd && s.pid != null && s.formula == null && s.decode == null)
+                issues += ValidationIssue(ValidationLevel.WARNING, id, key,
+                    "OBD sensor has neither 'formula' nor 'decode' — sensor will never produce a value",
+                    sensorPath(id, key, "formula"))
+
             // advertisement/gatt_notify 센서는 decode가 있어야 값 추출 가능
             if (device.source != Source.obd && s.decode == null && s.platform != "binary_sensor")
                 issues += ValidationIssue(ValidationLevel.WARNING, id, key,

--- a/app/src/test/java/dev/eigger/hassble/decode/ObdDecodeConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/ObdDecodeConfigTest.kt
@@ -1,0 +1,75 @@
+package dev.eigger.hassble.decode
+
+import dev.eigger.hassble.config.DataType
+import dev.eigger.hassble.config.DecodeConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * OBD 응답의 뒤쪽 바이트를 offset으로 읽는 경로.
+ * formula 변수(a~t)는 앞 20바이트까지만 닿으므로, 현대 21 03 블록의
+ * byte 57~60 총주행거리 같은 값은 decode로만 읽을 수 있다.
+ */
+class ObdDecodeConfigTest {
+
+    /** 현대 21 03 응답 모양: 62바이트 payload에 오도미터 3종을 심는다. */
+    private fun hyundai2103Payload(
+        odoAtRegenMeters: Long,
+        distSinceRegenMeters: Long,
+        odoMeters: Long,
+    ): ByteArray {
+        val data = ByteArray(62)
+        fun put(offset: Int, v: Long) {
+            for (i in 0 until 4) data[offset + i] = ((v shr (8 * (3 - i))) and 0xFF).toByte()
+        }
+        put(49, odoAtRegenMeters)
+        put(53, distSinceRegenMeters)
+        put(57, odoMeters)
+        return data
+    }
+
+    private val odometer = DecodeConfig(
+        offset = 57, length = 4, type = DataType.uint32, scale = 0.001,
+    )
+
+    @Test
+    fun `reads the odometer from byte 57`() {
+        val data = hyundai2103Payload(
+            odoAtRegenMeters = 186_000_000,
+            distSinceRegenMeters = 500_000,
+            odoMeters = 186_500_000,
+        )
+        assertEquals(186_500.0, Decoder.decodeStructured(data, odometer) as Double, 0.001)
+    }
+
+    @Test
+    fun `the three odometer fields stay independent`() {
+        val data = hyundai2103Payload(186_000_000, 500_000, 186_500_000)
+        val atRegen = DecodeConfig(offset = 49, length = 4, type = DataType.uint32, scale = 0.001)
+        val since = DecodeConfig(offset = 53, length = 4, type = DataType.uint32, scale = 0.001)
+
+        val a = Decoder.decodeStructured(data, atRegen) as Double
+        val s = Decoder.decodeStructured(data, since) as Double
+        val o = Decoder.decodeStructured(data, odometer) as Double
+
+        assertEquals(186_000.0, a, 0.001)
+        assertEquals(500.0, s, 0.001)
+        // 재생 시점 주행거리 + 재생 후 거리 = 현재 주행거리
+        assertEquals(o, a + s, 0.001)
+    }
+
+    @Test
+    fun `short response yields null instead of a wrong value`() {
+        // 가솔린처럼 21 03 프레임이 짧으면 byte 57에 닿지 못한다.
+        val short = ByteArray(40)
+        assertNull(Decoder.decodeStructured(short, odometer))
+    }
+
+    @Test
+    fun `full 32-bit range is unsigned`() {
+        val data = ByteArray(62) { 0 }
+        for (i in 57..60) data[i] = 0xFF.toByte()
+        assertEquals(4_294_967.295, Decoder.decodeStructured(data, odometer) as Double, 0.001)
+    }
+}


### PR DESCRIPTION
formula variables address only the first 20 bytes of a response, which is not enough for values that sit deep in a long frame. The Hyundai 21 03 block is the case at hand: it answers on the engine ECU with DPF data and the total odometer in one response, and the odometer (OBDb's HYUNDAI_ODO_V2) lives at bytes 57-60 as a 32-bit value divided by 1000.

Accept the existing `decode` block on OBD sensors and prefer it over `formula` when both are set. DecodeConfig and Decoder.decodeStructured are already used by advertisement and notify sensors, so this only wires the OBD dispatch path to them — offset, length, type, endian, scale, offset_value, bitmask and map all behave as they do elsewhere.

decodeStructured returns null when offset + length runs past the response, and emit() drops nulls, so a car whose frame is too short publishes nothing rather than a wrong number. A gasoline car with a short 21 03 block therefore stays silent instead of reporting garbage.

Also warn during validation when an OBD sensor has a pid but neither formula nor decode, since it can never produce a value. Presets are expanded into formula at load time, so preset-based sensors do not trip this.