### PR TITLE
feat(obd): log every command sent and every response that yields no v…

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -626,6 +626,11 @@ class NordicElm327Source(
 
                     if (txQueue.isNotEmpty() && now - lastTxAtMs >= txDelayMs) {
                         val item = txQueue.removeFirst()
+                        LiveEventLogger.log(
+                            LogType.TX,
+                            "device=${device.id}, cmd=${item.cmd}" +
+                                (item.pollTarget?.let { " (${it.sensor.key})" } ?: ""),
+                        )
                         val resp = sendCommand(device.id, txChar, item.cmd)
                         lastTxAtMs = System.currentTimeMillis()
 
@@ -635,14 +640,30 @@ class NordicElm327Source(
                             Log.d(TAG, "OBD dongle ready for ${device.id}")
                         }
 
-                        if (elmReady && item.pollTarget != null && resp != null) {
-                            ObdResponseParser.normalizeElm327Response(resp)?.let { hex ->
-                                onLinkStatus(
-                                    DeviceLinkStatus(device.id, DeviceLinkState.Polling, mac, System.currentTimeMillis()),
+                        val polled = item.pollTarget
+                        if (elmReady && polled != null) {
+                            val key = polled.sensor.key
+                            val hex = resp?.let { ObdResponseParser.normalizeElm327Response(it) }
+                            // 값이 안 나오는 이유를 로그만 보고 구분할 수 있어야 한다:
+                            // 무응답(NO DATA·타임아웃)인지, ECU가 명시적으로 거부한 것인지.
+                            val negative = hex?.let { ObdResponseParser.explainNegativeResponse(it) }
+                            when {
+                                hex == null -> LiveEventLogger.log(
+                                    LogType.RX,
+                                    "device=${device.id}, cmd=${item.cmd} ($key) → ${describeElmFailure(resp)}",
                                 )
-                                collector.emit(
-                                    RawReading(deviceId = device.id, source = "obd", rawHex = hex),
+                                negative != null -> LiveEventLogger.log(
+                                    LogType.RX,
+                                    "device=${device.id}, cmd=${item.cmd} ($key) → $negative",
                                 )
+                                else -> {
+                                    onLinkStatus(
+                                        DeviceLinkStatus(device.id, DeviceLinkState.Polling, mac, System.currentTimeMillis()),
+                                    )
+                                    collector.emit(
+                                        RawReading(deviceId = device.id, source = "obd", rawHex = hex),
+                                    )
+                                }
                             }
                         }
                         continue
@@ -753,6 +774,13 @@ class NordicElm327Source(
 
     private fun normalizeCommand(cmd: String): String =
         cmd.filter { !it.isWhitespace() }.lowercase()
+
+    /** 파싱되지 않은 ELM327 응답을 로그에 남길 한 줄로 요약한다. */
+    private fun describeElmFailure(resp: String?): String {
+        if (resp == null) return "no response (adapter write/notify failed)"
+        val text = resp.trim().replace(Regex("[\\r\\n>]+"), " ").trim()
+        return text.ifEmpty { "empty response" }
+    }
 
     private fun hexToBytes(hex: String): ByteArray? {
         val cleanHex = hex.replace(" ", "")

--- a/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
+++ b/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
@@ -21,6 +21,35 @@ object ObdResponseParser {
         return payload.joinToString("") { "%02X".format(it) }
     }
 
+    /**
+     * 정규화된 payload가 `7F <service> <nrc>` 부정 응답이면 사람이 읽을 설명을, 아니면 null.
+     *
+     * 부정 응답은 정규화 자체는 성공하므로(0x7F가 응답 모드 범위에 들어간다) 값 경로로 흘러가
+     * 조용히 버려진다. ECU가 "그 PID는 못 준다"고 답한 것과 아예 응답이 없는 것을 로그에서
+     * 구분하려면 여기서 따로 집어내야 한다.
+     */
+    fun explainNegativeResponse(payloadHex: String): String? {
+        val hex = payloadHex.uppercase().filter { it.isDigit() || it in 'A'..'F' }
+        if (!hex.startsWith("7F") || hex.length < 6) return null
+        val service = hex.substring(2, 4)
+        val nrc = hex.substring(4, 6)
+        return "negative response to service $service: NRC $nrc ${nrcName(nrc)}"
+    }
+
+    private fun nrcName(nrc: String): String = when (nrc) {
+        "10" -> "(generalReject)"
+        "11" -> "(serviceNotSupported)"
+        "12" -> "(subFunctionNotSupported)"
+        "13" -> "(incorrectMessageLengthOrInvalidFormat)"
+        "21" -> "(busyRepeatRequest)"
+        "22" -> "(conditionsNotCorrect)"
+        "24" -> "(requestSequenceError)"
+        "31" -> "(requestOutOfRange)"
+        "33" -> "(securityAccessDenied)"
+        "78" -> "(responsePending)"
+        else -> "(unknown)"
+    }
+
     /** ELM327 응답에서 16진 바이트열 추출 (줄 번호·공백·프롬프트 제거). */
     fun extractPayloadBytes(response: String): ByteArray? {
         val hex = buildString {

--- a/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
+++ b/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
@@ -50,20 +50,38 @@ object ObdResponseParser {
         else -> "(unknown)"
     }
 
-    /** ELM327 응답에서 16진 바이트열 추출 (줄 번호·공백·프롬프트 제거). */
+    private fun Char.isHexDigit(): Boolean = isDigit() || this in 'a'..'f' || this in 'A'..'F'
+
+    /**
+     * ELM327 응답에서 16진 바이트열 추출 (줄 번호·공백·프롬프트 제거).
+     *
+     * 멀티프레임 응답은 `0:`·`1:`… 로 번호가 붙은 줄로 오고, 그 앞에 전체 길이가
+     * **3자리 16진수** 한 줄로 먼저 온다. 길이에 A~F가 들어가면(예: 63바이트 → "03F")
+     * 그 줄이 데이터로 섞여 hex 길이가 홀수가 되고 응답 전체가 버려진다.
+     * 데이터는 항상 짝수 자리이므로, 번호 없는 줄은 3자리 이하일 때 길이 헤더로 보고 버린다.
+     *
+     * 번호 붙은 줄이 하나라도 있으면 그것만 쓴다. 같은 응답에 섞여 들어온 다른 조각을
+     * 데이터로 이어붙이지 않기 위한 것으로, ESPHome ble_elm327과 같은 방식이다.
+     */
     fun extractPayloadBytes(response: String): ByteArray? {
-        val hex = buildString {
-            for (line in response.split('\r', '\n')) {
-                var trimmed = line.trim().removePrefix(">").trim()
-                if (trimmed.isEmpty()) continue
-                if (trimmed.equals("SEARCHING...", ignoreCase = true)) continue
-                if (trimmed.matches(Regex("""\d{3}"""))) continue
-                if (':' in trimmed) trimmed = trimmed.substringAfter(':').trim()
-                for (c in trimmed) {
-                    if (c.isDigit() || c in 'a'..'f' || c in 'A'..'F') append(c)
-                }
+        val framed = StringBuilder()
+        val plain = StringBuilder()
+
+        for (line in response.split('\r', '\n')) {
+            val trimmed = line.trim().removePrefix(">").trim()
+            if (trimmed.isEmpty()) continue
+            if (trimmed.equals("SEARCHING...", ignoreCase = true)) continue
+
+            val colon = trimmed.indexOf(':')
+            if (colon > 0 && trimmed.take(colon).all { it.isDigit() }) {
+                trimmed.drop(colon + 1).filterTo(framed) { it.isHexDigit() }
+            } else {
+                val hex = trimmed.filter { it.isHexDigit() }
+                if (hex.length > 3) plain.append(hex)
             }
         }
+
+        val hex = if (framed.isNotEmpty()) framed.toString() else plain.toString()
         if (hex.length < 4 || hex.length % 2 != 0) return null
         return Decoder.hexToBytes(hex)
     }

--- a/app/src/test/java/dev/eigger/hassble/decode/Elm327MultilineTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/Elm327MultilineTest.kt
@@ -1,0 +1,81 @@
+package dev.eigger.hassble.decode
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * ELM327은 멀티프레임 응답 앞에 전체 길이를 3자리 16진수 한 줄로 찍는다.
+ * 길이에 A~F가 섞이는 순간 그 줄이 데이터로 오인돼 응답 전체가 버려지던 회귀를 막는다.
+ */
+class Elm327MultilineTest {
+
+    /** `0:`·`1:`… 로 번호가 붙은 ELM327 멀티프레임 출력을 만든다. */
+    private fun elmFrames(payloadHex: String): String {
+        val total = payloadHex.length / 2
+        val sb = StringBuilder("%03X\r".format(total))
+        var idx = 0
+        var line = 0
+        while (idx < payloadHex.length) {
+            val take = if (line == 0) 12 else 14   // 첫 줄 6바이트, 이후 7바이트
+            sb.append("$line:").append(payloadHex.substring(idx, minOf(idx + take, payloadHex.length))).append('\r')
+            idx += take
+            line++
+        }
+        return sb.append('>').toString()
+    }
+
+    @Test
+    fun `41-byte response with an all-digit length header`() {
+        // 실측 2101 응답. 41바이트 → 길이 "029" — 전부 숫자라 예전 코드도 통과했다.
+        val payload = "6101FFFFFFFF0026001E0C49515C8009251300FF1A89000900000049B550FF1E03000026FFFFFFFF55"
+        assertEquals(41, payload.length / 2)
+        assertEquals(payload, ObdResponseParser.normalizeElm327Response(elmFrames(payload)))
+    }
+
+    @Test
+    fun `63-byte response whose length header contains a hex letter`() {
+        // 2103이 byte 57~60을 담으려면 63바이트 → 길이 "03F".
+        // 'F' 때문에 예전 코드는 길이 줄을 데이터로 붙여 hex를 홀수로 만들고 null을 냈다.
+        val payload = "6103" + "AB".repeat(61)
+        assertEquals(63, payload.length / 2)
+        assertEquals("03F", "%03X".format(63))
+
+        val hex = ObdResponseParser.normalizeElm327Response(elmFrames(payload))
+        assertNotNull("길이 헤더 03F가 데이터로 섞이면 안 된다", hex)
+        assertEquals(payload, hex)
+    }
+
+    @Test
+    fun `the odometer survives the round trip`() {
+        // byte 57~60 = 0x0B1C9E60 = 186,000,480 → /1000 = 186000.48 km
+        val data = ByteArray(61)
+        val odo = 186_000_480L
+        for (i in 0 until 4) data[57 + i] = ((odo shr (8 * (3 - i))) and 0xFF).toByte()
+        val payload = "6103" + data.joinToString("") { "%02X".format(it) }
+
+        val hex = ObdResponseParser.normalizeElm327Response(elmFrames(payload))!!
+        val (mode, pid, bytes) = Decoder.parseObdPayloadHex(hex)!!
+        assertEquals("21", mode)
+        assertEquals("03", pid)
+        assertEquals(61, bytes.size)
+
+        var v = 0L
+        for (i in 57..60) v = (v shl 8) or (bytes[i].toLong() and 0xFF)
+        assertEquals(186_000.48, v * 0.001, 0.001)
+    }
+
+    @Test
+    fun `single frame responses are unaffected`() {
+        assertEquals("410C0D2A", ObdResponseParser.normalizeElm327Response("410C0D2A\r\r>"))
+    }
+
+    @Test
+    fun `two ECUs answering a broadcast are still concatenated`() {
+        // ATSH7DF 로 나간 010C 에 두 ECU가 답하면 두 줄이 온다.
+        assertEquals(
+            "410C0D2A410C0D2A",
+            ObdResponseParser.normalizeElm327Response("410C0D2A\r410C0D2A\r>"),
+        )
+    }
+}

--- a/app/src/test/java/dev/eigger/hassble/decode/NegativeResponseTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/NegativeResponseTest.kt
@@ -1,0 +1,51 @@
+package dev.eigger.hassble.decode
+
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NegativeResponseTest {
+
+    @Test
+    fun `explains the cluster refusal seen on the Accent`() {
+        // 엑센트 RB가 ATSH7C6 + 22B002 에 돌려준 실제 응답
+        val msg = ObdResponseParser.explainNegativeResponse("7F2222")
+        assertTrue(msg, msg!!.contains("service 22"))
+        assertTrue(msg, msg.contains("NRC 22"))
+        assertTrue(msg, msg.contains("conditionsNotCorrect"))
+    }
+
+    @Test
+    fun `handles spacing and prompt characters`() {
+        val msg = ObdResponseParser.explainNegativeResponse("7F 22 31 \r>")
+        assertTrue(msg, msg!!.contains("requestOutOfRange"))
+    }
+
+    @Test
+    fun `a 7F byte inside a positive payload is not mistaken for a refusal`() {
+        // 데이터 중간의 7F는 부정 응답이 아니다 — payload 선두만 본다.
+        assertNull(ObdResponseParser.explainNegativeResponse("61037F2222FFFF"))
+    }
+
+    @Test
+    fun `the refusal survives ISO-TP normalization`() {
+        val hex = ObdResponseParser.normalizeElm327Response("7F2222\r\r>")
+        assertTrue(ObdResponseParser.explainNegativeResponse(hex!!) != null)
+    }
+
+    @Test
+    fun `positive responses are not flagged`() {
+        assertNull(ObdResponseParser.explainNegativeResponse("410C0D2A"))
+        assertNull(ObdResponseParser.explainNegativeResponse("6101FFFFFFFF0026"))
+    }
+
+    @Test
+    fun `NO DATA is not a negative response`() {
+        assertNull(ObdResponseParser.explainNegativeResponse("NO DATA"))
+    }
+
+    @Test
+    fun `truncated negative response does not crash`() {
+        assertNull(ObdResponseParser.explainNegativeResponse("7F22"))
+    }
+}


### PR DESCRIPTION
…alue

An Accent RB diesel showed empty odometer sensors with nothing in the log to explain why. Only successfully parsed responses were logged, so a poll that returned NO DATA, timed out, or was refused by the ECU left no trace at all — the sensor simply stayed blank and there was no way to tell whether the request had even gone out.

Log each transmitted command as TX, tagged with the sensor key when the command is a poll, so "never requested" is distinguishable from "requested, no answer".

Log as RX the two cases that previously vanished:

- the response could not be normalized (NO DATA, timeout, adapter failure), reported with the raw ELM327 text
- the response is a UDS negative response, reported with the service and the NRC name

The negative-response case needs its own branch because 0x7F falls inside the response-mode range that normalizeElm327Response accepts, so a refusal parsed "successfully" and was then dropped downstream when no sensor matched its decoded mode and pid. explainNegativeResponse only inspects the head of a normalized payload, so a 0x7F byte sitting in the middle of real data is not mistaken for a refusal.