### PR TITLE
fix(obd): keep one ELM327 prompt to one response

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -497,6 +497,9 @@ class NordicElm327Source(
     private val deviceMutexes = java.util.concurrent.ConcurrentHashMap<String, Mutex>()
     private val pendingDeferreds = java.util.concurrent.ConcurrentHashMap<String, CompletableDeferred<String>>()
 
+    // ELM327 수신 버퍼. 명령을 보내기 직전에 비워야 앞 명령의 늦은 응답이 섞이지 않는다.
+    private val rxBuffers = java.util.concurrent.ConcurrentHashMap<String, StringBuilder>()
+
     private data class PollTarget(
         val sensor: SensorConfig,
         var nextPollAtMs: Long = 0L,
@@ -580,15 +583,18 @@ class NordicElm327Source(
 
             if (txChar == null) throw IllegalStateException("OBD TX characteristic not found")
 
-            val responseBuffer = StringBuilder()
+            val responseBuffer = rxBuffers.getOrPut(device.id) { StringBuilder() }
+            responseBuffer.setLength(0)
             val rxJob = launch {
                 rxChar.getNotifications().collect { bytes ->
-                    val chunk = String(bytes.value, Charsets.US_ASCII)
-                    responseBuffer.append(chunk)
-                    if (responseBuffer.contains(">")) {
-                        val fullResponse = responseBuffer.toString().trim()
-                        responseBuffer.clear()
-                        pendingDeferreds[device.id]?.complete(fullResponse)
+                    val responses = synchronized(responseBuffer) {
+                        responseBuffer.append(String(bytes.value, Charsets.US_ASCII))
+                        ObdResponseParser.drainCompleteResponses(responseBuffer)
+                    }
+                    // 응답 하나가 대기 중인 명령 하나에 대응한다. 짝이 없는 응답은
+                    // 앞 명령이 타임아웃된 뒤 늦게 온 것이므로 버린다.
+                    for (response in responses) {
+                        pendingDeferreds.remove(device.id)?.complete(response)
                     }
                 }
             }
@@ -714,10 +720,18 @@ class NordicElm327Source(
     ): String? {
         val mutex = deviceMutexes.getOrPut(deviceId) { Mutex() }
         return mutex.withLock {
+            // 직전 명령이 타임아웃된 뒤 늦게 도착한 조각이 남아 있으면 이번 응답 앞에 붙는다.
+            rxBuffers[deviceId]?.let { synchronized(it) { it.setLength(0) } }
             val deferred = CompletableDeferred<String>()
             pendingDeferreds[deviceId] = deferred
             val payload = (cmd + "\r").toByteArray(Charsets.US_ASCII)
-            val timeoutMs = if (cmd.length >= 6) MULTIFRAME_TIMEOUT_MS else SINGLE_FRAME_TIMEOUT_MS
+            // mode 21/22 블록 응답은 60바이트를 넘기도 한다. 명령 길이로는 길이를 알 수 없으니
+            // AT 명령만 짧게 잡고 나머지 데이터 요청은 넉넉한 쪽을 쓴다.
+            val timeoutMs = if (cmd.trim().uppercase().startsWith("AT")) {
+                SINGLE_FRAME_TIMEOUT_MS
+            } else {
+                MULTIFRAME_TIMEOUT_MS
+            }
 
             try {
                 txChar.write(DataByteArray(payload), BleWriteType.NO_RESPONSE)
@@ -765,6 +779,7 @@ class NordicElm327Source(
         activeConnections.remove(deviceId)?.disconnect()
         deviceMutexes.remove(deviceId)
         pendingDeferreds.remove(deviceId)
+        rxBuffers.remove(deviceId)
     }
 
     private fun isDuplicateInit(cmd: String): Boolean {

--- a/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
+++ b/app/src/main/java/dev/eigger/hassble/decode/ObdResponseParser.kt
@@ -50,6 +50,24 @@ object ObdResponseParser {
         else -> "(unknown)"
     }
 
+    /**
+     * 수신 버퍼에서 `>` 프롬프트로 끝난 응답들을 잘라내고, 남은 조각은 버퍼에 그대로 둔다.
+     *
+     * 한 BLE 알림에 프롬프트가 여러 개 실려 올 수 있다. 버퍼를 통째로 비우면 두 응답이
+     * 한 덩어리로 합쳐지고 뒤엣것이 사라져, 이후 명령이 앞 명령의 응답을 받게 된다.
+     */
+    fun drainCompleteResponses(buffer: StringBuilder): List<String> {
+        val out = mutableListOf<String>()
+        var prompt = buffer.indexOf(">")
+        while (prompt >= 0) {
+            val response = buffer.substring(0, prompt).trim()
+            buffer.delete(0, prompt + 1)
+            if (response.isNotEmpty()) out += response
+            prompt = buffer.indexOf(">")
+        }
+        return out
+    }
+
     private fun Char.isHexDigit(): Boolean = isDigit() || this in 'a'..'f' || this in 'A'..'F'
 
     /**

--- a/app/src/test/java/dev/eigger/hassble/decode/RxBufferTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/RxBufferTest.kt
@@ -24,9 +24,10 @@ class RxBufferTest {
 
     @Test
     fun `a partial response is kept for the next notification`() {
+        // 긴 응답이 알림 두 개로 쪼개져 도착한다. 청크는 그대로 이어붙는다.
         val buf = StringBuilder()
-        assertTrue(drain(buf, "0:6103AA").isEmpty())
-        assertEquals(listOf("0:6103AA\rBBCC\r1:DDEE"), drain(buf, "BBCC\r1:DDEE\r>"))
+        assertTrue(drain(buf, "0:6103AABBCC\r1:DD").isEmpty())
+        assertEquals(listOf("0:6103AABBCC\r1:DDEE"), drain(buf, "EE\r>"))
         assertEquals(0, buf.length)
     }
 

--- a/app/src/test/java/dev/eigger/hassble/decode/RxBufferTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/RxBufferTest.kt
@@ -1,0 +1,54 @@
+package dev.eigger.hassble.decode
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * ELM327 수신 버퍼에서 응답을 잘라내는 규칙.
+ * 프롬프트 하나가 응답 하나이며, 뒤에 남은 조각은 다음 응답의 시작이므로 보존해야 한다.
+ */
+class RxBufferTest {
+
+    private fun drain(buffer: StringBuilder, chunk: String): List<String> {
+        buffer.append(chunk)
+        return ObdResponseParser.drainCompleteResponses(buffer)
+    }
+
+    @Test
+    fun `two responses in one notification stay separate`() {
+        val buf = StringBuilder()
+        assertEquals(listOf("410C0D2A", "410D00"), drain(buf, "410C0D2A\r>410D00\r>"))
+        assertEquals(0, buf.length)
+    }
+
+    @Test
+    fun `a partial response is kept for the next notification`() {
+        val buf = StringBuilder()
+        assertTrue(drain(buf, "0:6103AA").isEmpty())
+        assertEquals(listOf("0:6103AA\rBBCC\r1:DDEE"), drain(buf, "BBCC\r1:DDEE\r>"))
+        assertEquals(0, buf.length)
+    }
+
+    @Test
+    fun `trailing data after a prompt survives`() {
+        val buf = StringBuilder()
+        assertEquals(listOf("410C0D2A"), drain(buf, "410C0D2A\r>410D"))
+        assertEquals("410D", buf.toString())
+        assertEquals(listOf("410D00"), drain(buf, "00\r>"))
+    }
+
+    @Test
+    fun `a bare prompt yields nothing`() {
+        val buf = StringBuilder()
+        assertTrue(drain(buf, ">").isEmpty())
+        assertTrue(drain(buf, "\r\r>").isEmpty())
+    }
+
+    @Test
+    fun `one response per notification is unchanged`() {
+        val buf = StringBuilder()
+        assertEquals(listOf("410C0D2A"), drain(buf, "410C0D2A\r>"))
+        assertEquals(listOf("410D00"), drain(buf, "410D00\r>"))
+    }
+}


### PR DESCRIPTION
The RX buffer was drained with a single check and then cleared outright:

    if (responseBuffer.contains(">")) {
        val fullResponse = responseBuffer.toString().trim()
        responseBuffer.clear()
        pendingDeferreds[device.id]?.complete(fullResponse)
    }

A BLE notification can carry more than one prompt. When it does, both replies were handed over as one string and everything after the first prompt was thrown away, so the next command received the previous command's text and every reply after it was off by one. A partial reply left over from a command that had already timed out was prepended to the next one the same way.

Drain the buffer the way the ESPHome ble_elm327 component does: cut at each prompt in a loop, keep what follows for the next notification, and hand each reply to one waiting command. A reply with no command waiting is a late arrival and is dropped. The buffer is also reset before each write and on teardown so a stale fragment cannot leak into a fresh command.

Also stop choosing the read timeout by command length. `cmd.length >= 6` was standing in for "this might be multi-frame", which mode 21 block requests are too — 21 03 answers with more than 60 bytes but is only four characters long. Give AT commands the short timeout and every data request the long one.