### PR TITLE
perf(obd): stop busy-polling the sensor schedule every 10ms

### DIFF
--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -699,7 +699,13 @@ class NordicElm327Source(
                                 break
                             }
                         }
-                        if (!scheduled) delay(POLL_LOOP_MS)
+                        if (!scheduled) {
+                            // 다음 센서가 준비될 때까지 정확히 잔다. 10ms 간격으로 계속
+                            // 깨어나면(60s 주기 센서라도 초당 100번) 드라이브 내내 CPU가
+                            // 딥슬립에 못 들어가 배터리를 크게 갉아먹는다. nextPollAtMs는
+                            // 이 루프 밖에서 바뀌지 않으므로 안전하게 최솟값까지 잘 수 있다.
+                            delay(computeIdleWaitMs(targets.map { it.nextPollAtMs }, now))
+                        }
                     } else {
                         delay(POLL_LOOP_MS)
                     }
@@ -808,6 +814,14 @@ class NordicElm327Source(
     companion object {
 
         private const val POLL_LOOP_MS = 10L
+        // 유휴 대기의 상한. nextPollAtMs가 이 루프 밖에서 바뀌지 않으므로 정확히 그때까지
+        // 자도 되지만, 혹시 모를 지연을 대비해 5초를 넘기지는 않는다.
+        private const val MAX_IDLE_WAIT_MS = 5_000L
+
+        /** 가장 빨리 준비될 센서까지 몇 ms 자야 하는지. [POLL_LOOP_MS, MAX_IDLE_WAIT_MS]로 제한. */
+        fun computeIdleWaitMs(nextPollAtMs: List<Long>, now: Long): Long =
+            (nextPollAtMs.min() - now).coerceIn(POLL_LOOP_MS, MAX_IDLE_WAIT_MS)
+
         private const val SINGLE_FRAME_TIMEOUT_MS = 2_000L
         private const val MULTIFRAME_TIMEOUT_MS = 5_000L
     }

--- a/app/src/test/java/dev/eigger/hassble/ble/IdleWaitTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/IdleWaitTest.kt
@@ -1,0 +1,41 @@
+package dev.eigger.hassble.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 유휴 구간에서 다음 센서까지 정확히 자는 시간을 계산하는 로직.
+ * 이전에는 10ms마다 계속 깨어나 확인했는데, 60s 주기 센서라도 초당 100번
+ * 깨어나 드라이브 내내 배터리를 소모했다.
+ */
+class IdleWaitTest {
+
+    @Test
+    fun `waits exactly until the nearest sensor is due`() {
+        val now = 1_000_000L
+        val nextPollAtMs = listOf(now + 950, now + 30_000, now + 5_000)
+        assertEquals(950L, NordicElm327Source.computeIdleWaitMs(nextPollAtMs, now))
+    }
+
+    @Test
+    fun `never waits less than the loop floor`() {
+        val now = 1_000_000L
+        // 이미 지났어야 할 시각(음수 차이)이 들어와도 음수로 delay() 하지 않는다.
+        val nextPollAtMs = listOf(now - 5, now + 100)
+        assertEquals(10L, NordicElm327Source.computeIdleWaitMs(nextPollAtMs, now))
+    }
+
+    @Test
+    fun `caps a long-idle sensor set to the max wait`() {
+        val now = 1_000_000L
+        // 모든 센서가 60s 주기여도 5s 넘게 자지는 않는다.
+        val nextPollAtMs = listOf(now + 60_000, now + 45_000)
+        assertEquals(5_000L, NordicElm327Source.computeIdleWaitMs(nextPollAtMs, now))
+    }
+
+    @Test
+    fun `a single sensor uses its own due time`() {
+        val now = 1_000_000L
+        assertEquals(1_000L, NordicElm327Source.computeIdleWaitMs(listOf(now + 1_000), now))
+    }
+}


### PR DESCRIPTION
The OBD poll loop woke up on a fixed 10ms tick whenever no sensor was due, regardless of how far away the next one actually was. A sensor polled every 60s still triggered ~100 wakeups per second for the entire connection — 180,000 wakeups over a 30-minute drive versus the roughly 1,800 actually needed if it slept until the next sensor's due time. This runs inside a foreground service for as long as the OBD adapter stays connected, so it kept the CPU from reaching deep sleep for the whole trip — a plausible explanation for reports of high battery drain while connected.

nextPollAtMs is only ever written inside this same loop, so sleeping exactly until the earliest one is due changes nothing about correctness or responsiveness; it only removes the wasted wakeups in between. Extract the computation as computeIdleWaitMs, floored at the existing 10ms tick (guards against delay() on a negative or zero duration) and capped at 5s as a safety margin, so the loop still checks in periodically rather than sleeping for an unbounded stretch.

The two other delay(POLL_LOOP_MS) call sites are unchanged: one covers the brief startup window before ELM327 init completes, the other waits out tx_delay between queued commands (typically tens of milliseconds) — neither runs for the bulk of a connection's lifetime the way the idle-wait branch did.