### PR TITLE
perf(ble): cut background battery drain from OBD polling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 62
-        versionName = "1.1.0"
+        versionCode = 63
+        versionName = "1.1.1"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -392,7 +392,11 @@ class BleRuntime(
                                 } else {
                                     onLinkStatus(DeviceLinkStatus(resolved.id, DeviceLinkState.Scanning, mac))
                                     LiveEventLogger.log(LogType.LINK, "device=${resolved.id}: waiting for advertisement from $mac")
-                                    scanner.scanForMac(mac, scanMode).first()
+                                    // 재연결 대기는 latency가 중요하지 않다(차가 다시 켜져야 광고가
+                                    // 뜨는데, 그건 초 단위가 아니라 분·시간 단위로 벌어지는 일).
+                                    // 사용자가 실시간 스캔용으로 고른 scanMode(BALANCED/LOW_LATENCY)를
+                                    // 그대로 쓰면 주차 내내 그 듀티사이클로 스캔이 돌아 배터리를 갉아먹는다.
+                                    scanner.scanForMac(mac, BleScanModeOption.LOW_POWER).first()
                                 }
                             }, autoReconnect = autoReconnect).collect { reading ->
                                 onReading(reading)
@@ -420,7 +424,8 @@ class BleRuntime(
                                 } else {
                                     onLinkStatus(DeviceLinkStatus(resolved.id, DeviceLinkState.Scanning, mac))
                                     LiveEventLogger.log(LogType.LINK, "device=${resolved.id}: waiting for advertisement from $mac")
-                                    scanner.scanForMac(mac, scanMode).first()
+                                    // 위 GATT notify 경로와 같은 이유로 재연결 대기는 LOW_POWER 고정.
+                                    scanner.scanForMac(mac, BleScanModeOption.LOW_POWER).first()
                                 }
                             }, autoReconnect = autoReconnect).collect { reading ->
                                 onReading(reading)
@@ -467,19 +472,23 @@ class BleRuntime(
             Source.obd, Source.gatt_notify -> LogType.NOTIF
             else -> LogType.ADV
         }
-        val info = buildString {
-            append("device=${d.id}")
-            r.macAddress?.let { append(", mac=$it") }
-            r.deviceName?.let { append(", name=$it") }
-            if (d.source == Source.advertisement) {
-                r.manufacturerHex?.let { append(", mfg=$it") }
-                r.serviceDataHex?.let { append(", svc=$it") }
-                r.isConnectable?.let { append(", connectable=$it") }
-            } else {
-                append(", raw=${r.rawHex}")
+        // ADV 타입은 includeAdvLogs가 꺼져 있으면(기본값) log()가 버리므로, 버릴 문자열을
+        // 광고 패킷마다(주행 중엔 초당 수십 건) 조립하는 비용부터 건너뛴다.
+        if (logType != LogType.ADV || LiveEventLogger.includeAdvLogs) {
+            val info = buildString {
+                append("device=${d.id}")
+                r.macAddress?.let { append(", mac=$it") }
+                r.deviceName?.let { append(", name=$it") }
+                if (d.source == Source.advertisement) {
+                    r.manufacturerHex?.let { append(", mfg=$it") }
+                    r.serviceDataHex?.let { append(", svc=$it") }
+                    r.isConnectable?.let { append(", connectable=$it") }
+                } else {
+                    append(", raw=${r.rawHex}")
+                }
             }
+            LiveEventLogger.log(logType, info)
         }
-        LiveEventLogger.log(logType, info)
 
         val out = mutableListOf<Pair<String, Any>>()
 

--- a/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/NordicBleSources.kt
@@ -176,26 +176,31 @@ class NordicAdvertisementScanner(private val context: Context) : AdvertisementSc
                     val advertisedServiceUuids = serviceUuidsCache[deviceAddress] ?: scanRecord?.serviceUuids.orEmpty()
                     val rawBytes = scanRecord?.bytes
 
-                    val mfrHex = manufacturerData?.let {
-                        val list = mutableListOf<String>()
-                        for (i in 0 until it.size()) {
-                            val id = it.keyAt(i)
-                            val bytes = it.valueAt(i).value
-                            list.add("0x%04X: %s".format(id, bytes.joinToString("") { String.format("%02X", it) }))
+                    // LiveEventLogger.log()는 includeAdvLogs가 꺼져 있으면(기본값) ADV 항목을
+                    // 그냥 버린다. 그런데 이 hex 포맷팅 자체가 스캔 결과마다(주행 중엔 초당
+                    // 수십 건) 도는 비용이라, 로그를 쓸 게 아니면 애초에 만들지 않는다.
+                    if (LiveEventLogger.includeAdvLogs) {
+                        val mfrHex = manufacturerData?.let {
+                            val list = mutableListOf<String>()
+                            for (i in 0 until it.size()) {
+                                val id = it.keyAt(i)
+                                val bytes = it.valueAt(i).value
+                                list.add("0x%04X: %s".format(id, bytes.joinToString("") { String.format("%02X", it) }))
+                            }
+                            list.joinToString(", ")
                         }
-                        list.joinToString(", ")
+                        val svcHex = serviceData.entries.joinToString(", ") { (key, value) ->
+                            "${getShortUuid(key.uuid)}: ${value.value.joinToString("") { String.format("%02X", it) }}"
+                        }
+                        val logMsg = buildString {
+                            append("addr=$deviceAddress")
+                            if (deviceName.isNotBlank()) append(", name='$deviceName'")
+                            if (!mfrHex.isNullOrBlank()) append(", mfr=[$mfrHex]")
+                            if (svcHex.isNotBlank()) append(", svc=[$svcHex]")
+                            isConnectable?.let { append(", connectable=$it") }
+                        }
+                        LiveEventLogger.log(LogType.ADV, logMsg)
                     }
-                    val svcHex = serviceData.entries.joinToString(", ") { (key, value) ->
-                        "${getShortUuid(key.uuid)}: ${value.value.joinToString("") { String.format("%02X", it) }}"
-                    }
-                    val logMsg = buildString {
-                        append("addr=$deviceAddress")
-                        if (deviceName.isNotBlank()) append(", name='$deviceName'")
-                        if (!mfrHex.isNullOrBlank()) append(", mfr=[$mfrHex]")
-                        if (svcHex.isNotBlank()) append(", svc=[$svcHex]")
-                        isConnectable?.let { append(", connectable=$it") }
-                    }
-                    LiveEventLogger.log(LogType.ADV, logMsg)
 
                     if ((manufacturerData != null && manufacturerData.size() > 0) || serviceData.isNotEmpty()) {
                         val mfrIds = (0 until (manufacturerData?.size() ?: 0)).map { manufacturerData!!.keyAt(it) }

--- a/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
+++ b/app/src/main/java/dev/eigger/hassble/net/HaWsClient.kt
@@ -60,7 +60,10 @@ class HaWsClient(
     private val refreshToken: String? = null,
     private val onTokenRefreshed: (suspend (String) -> Unit)? = null,
     private val http: OkHttpClient = OkHttpClient.Builder()
-        .pingInterval(5, java.util.concurrent.TimeUnit.SECONDS)
+        // 5초는 라디오를 절전 상태로 못 내려가게 만들 만큼 잦다(하루 종일, OBD 동작 여부와
+        // 무관하게). 30초는 대부분의 통신사 NAT idle timeout보다 짧으면서 웨이크업 빈도를
+        // 1/6로 줄인다.
+        .pingInterval(30, java.util.concurrent.TimeUnit.SECONDS)
         .build(),
 ) {
     private val json = Json {

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -65,6 +65,9 @@ class BleGatewayService : Service() {
     private var currentGitToken: String? = null
     private var currentConfig: GatewayConfig? = null
     @Volatile private var pendingEntityCleanupDeviceIds: Set<String> = emptySet()
+    // link_status는 폴링마다(초 단위) onLinkStatus가 여러 번 호출되지만 값은 대부분 "on"으로
+    // 동일하다. 실제로 값이 바뀔 때만 WS로 보내 불필요한 프레임 전송을 없앤다.
+    private val lastSentLinkConnected = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
 
     override fun onCreate() {
         super.onCreate()
@@ -311,9 +314,12 @@ class BleGatewayService : Service() {
                     ws?.let { client ->
                         if (client.connectionState.value == ConnectionState.Connected) {
                             val isConnected = status.state == dev.eigger.hassble.ble.DeviceLinkState.Connected || status.state == dev.eigger.hassble.ble.DeviceLinkState.Polling
-                            client.sendStates(listOf(
-                                "${status.profileId}_link_status" to if (isConnected) "on" else "off",
-                            ))
+                            val previous = lastSentLinkConnected.put(status.profileId, isConnected)
+                            if (previous != isConnected) {
+                                client.sendStates(listOf(
+                                    "${status.profileId}_link_status" to if (isConnected) "on" else "off",
+                                ))
+                            }
                         }
                     }
                 }
@@ -432,6 +438,7 @@ class BleGatewayService : Service() {
         runtime = null
         ws = null
         pendingEntityCleanupDeviceIds = emptySet()
+        lastSentLinkConnected.clear()
         _isServiceRunning.value = false
         _serviceConnectionState.value = ConnectionState.Disconnected
         _connectionIssue.value = ConnectionIssue.None

--- a/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/LiveEventLogger.kt
@@ -61,7 +61,9 @@ object LiveEventLogger {
     private val _logFlow = MutableSharedFlow<LogEntry>(extraBufferCapacity = BUFFER_LIMIT_OPTIONS.max())
     val logFlow = _logFlow.asSharedFlow()
 
-    private val _logs = mutableListOf<LogEntry>()
+    // ArrayList.removeAt(0)은 O(n) 시프트라 로그가 잦을 때(WS/OBD TX·RX 등) 누적 비용이 커진다.
+    // ArrayDeque는 removeAt(0)/removeFirst()가 O(1)이라 같은 링버퍼 용도에 더 저렴하다.
+    private val _logs = ArrayDeque<LogEntry>()
     val logs: List<LogEntry>
         get() = synchronized(_logs) { ArrayList(_logs) }
 


### PR DESCRIPTION
- Force LOW_POWER scan mode for background reconnect-wait scans instead of reusing the user's live scanMode (BALANCED/LOW_LATENCY), since latency doesn't matter while parked waiting for the dongle to reappear.
- Dedupe link_status WS state sends: onLinkStatus fires twice per poll (source class + onLinkDataReceived) with the same value; only send when the connected/disconnected value actually changes.
- Reduce OkHttp WS ping interval from 5s to 30s, cutting radio wake frequency 6x while staying under typical carrier NAT timeouts.
- Skip building advertisement log strings (hex formatting) when includeAdvLogs is off, since LiveEventLogger already discards them.
- Switch LiveEventLogger's ring buffer from ArrayList to ArrayDeque for O(1) eviction instead of an O(n) shift on every log call.

Bump versionCode/versionName to 63/1.1.1.