### PR TITLE
feat(ble): BLE 광고 송신(주차위치 요청) 기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 64
-        versionName = "1.2.0"
+        versionCode = 65
+        versionName = "1.3.0"
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
         tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
         tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE"
+        tools:targetApi="s" />
 
     <!-- BLE 스캔에는 모든 Android 버전에서 위치 권한이 필요 (Android 12+ 포함, neverForLocation 미사용) -->
     <uses-permission android:name="android.permission.BLUETOOTH"

--- a/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
@@ -1,5 +1,6 @@
 package dev.eigger.hassble.ble
 
+import dev.eigger.hassble.config.AdvertiseConfig
 import dev.eigger.hassble.config.BleScanModeOption
 import dev.eigger.hassble.config.DeviceConfig
 import kotlinx.coroutines.flow.Flow
@@ -99,3 +100,25 @@ interface Elm327Source {
         }
     }
 }
+
+/** 경로 D: 광고 송신(TX). config의 hex payload를 BLE manufacturer data로 브로드캐스트. */
+interface BleAdvertiser {
+    /**
+     * [counterSeed]부터 시작해 광고를 켠다. 이미 켜져 있으면 재시작한다.
+     * timeout / repeat_interval 스케줄링은 구현체가 담당한다.
+     * [onCounter]는 counter가 바뀔 때마다(영속 저장용), [onStopped]는 어떤 이유로든
+     * 송신이 끝났을 때 호출된다.
+     */
+    fun start(
+        deviceId: String,
+        config: AdvertiseConfig,
+        counterSeed: Int,
+        onCounter: (Int) -> Unit = {},
+        onStopped: (AdvertiseStopReason) -> Unit = {},
+    )
+    fun stop(deviceId: String, reason: AdvertiseStopReason = AdvertiseStopReason.Manual)
+    fun stopAll()
+    fun isAdvertising(deviceId: String): Boolean
+}
+
+enum class AdvertiseStopReason { Manual, Timeout, ResponseReceived, Error, Shutdown }

--- a/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
@@ -115,7 +115,7 @@ interface BleAdvertiser {
         counterSeed: Int,
         onCounter: (Int) -> Unit = {},
         onStopped: (AdvertiseStopReason) -> Unit = {},
-    )
+    ): Boolean
     fun stop(deviceId: String, reason: AdvertiseStopReason = AdvertiseStopReason.Manual)
     fun stopAll()
     fun isAdvertising(deviceId: String): Boolean

--- a/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
@@ -1,0 +1,65 @@
+package dev.eigger.hassble.ble
+
+object AdvertisePayload {
+    /** legacy 광고 31바이트 - flags AD(3) - AD 헤더(2) - company ID(2) = 24바이트 */
+    const val MAX_MANUFACTURER_PAYLOAD = 24
+
+    private val TOKEN_REGEX = Regex("""\{counter(?::([^}]+))?\}""")
+
+    /** counter는 1바이트 순환 (0~255). */
+    fun nextCounter(current: Int): Int = (current + 1) and 0xFF
+
+    /**
+     * {counter} → 10진수, {counter:02X} → String.format 적용.
+     * 토큰이 없으면 원문 그대로 반환한다.
+     */
+    fun render(template: String, counter: Int): String {
+        return TOKEN_REGEX.replace(template) { m ->
+            val fmt = m.groupValues[1]
+            if (fmt.isEmpty()) {
+                counter.toString()
+            } else {
+                runCatching { String.format("%$fmt", counter) }.getOrElse { counter.toString() }
+            }
+        }
+    }
+
+    /** 렌더된 hex를 바이트로. 홀수 길이·비 hex 문자면 null. */
+    fun toBytes(rendered: String): ByteArray? {
+        val clean = rendered.trim()
+        if (clean.length % 2 != 0) return null
+        val result = ByteArray(clean.length / 2)
+        for (i in clean.indices step 2) {
+            val high = Character.digit(clean[i], 16)
+            val low = Character.digit(clean[i + 1], 16)
+            if (high == -1 || low == -1) return null
+            result[i / 2] = ((high shl 4) or low).toByte()
+        }
+        return result
+    }
+
+    /** 설정 검증용. 성공하면 null, 실패하면 사람이 읽을 수 있는 사유. */
+    fun validationError(template: String): String? {
+        if (template.isBlank()) return "payload cannot be blank"
+        val testCounters = listOf(0, 255)
+        for (c in testCounters) {
+            val rendered = try {
+                TOKEN_REGEX.replace(template) { m ->
+                    val fmt = m.groupValues[1]
+                    if (fmt.isEmpty()) c.toString() else String.format("%$fmt", c)
+                }
+            } catch (e: Exception) {
+                return "invalid token format in payload: ${e.message}"
+            }
+            val bytes = toBytes(rendered)
+                ?: return "payload '$rendered' is not a valid hex string"
+            if (bytes.isEmpty()) {
+                return "payload cannot be empty"
+            }
+            if (bytes.size > MAX_MANUFACTURER_PAYLOAD) {
+                return "payload size (${bytes.size} bytes) exceeds maximum legacy advertisement limit ($MAX_MANUFACTURER_PAYLOAD bytes)"
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -67,9 +67,6 @@ class AndroidBleAdvertiser(
         return adapter.bluetoothLeAdvertiser
     }
 
-    // Permission check has already been performed in hasAdvertisePermission() before calling
-    // BluetoothLeAdvertiser methods. Any runtime revocation surfaces as SecurityException and is
-    // caught cleanly.
     @SuppressLint("MissingPermission")
     override fun start(
         deviceId: String,
@@ -77,19 +74,17 @@ class AndroidBleAdvertiser(
         counterSeed: Int,
         onCounter: (Int) -> Unit,
         onStopped: (AdvertiseStopReason) -> Unit,
-    ) {
+    ): Boolean {
         // If already advertising for this device, stop existing session first
         if (sessions.containsKey(deviceId)) {
             stop(deviceId, AdvertiseStopReason.Manual)
         }
 
         if (!hasAdvertisePermission()) {
-            LiveEventLogger.log(
-                LogType.TX,
-                "BLE Advertise failed: BLUETOOTH_ADVERTISE permission not granted (device=$deviceId)",
-            )
+            val msg = "${context.getString(R.string.log_advertise_no_permission)} (device=$deviceId)"
+            LiveEventLogger.log(LogType.TX, msg)
             onStopped(AdvertiseStopReason.Error)
-            return
+            return false
         }
 
         val advertiser = getBluetoothAdvertiser()
@@ -98,11 +93,11 @@ class AndroidBleAdvertiser(
             val adapter = manager?.adapter
             val reason = when {
                 adapter == null || !adapter.isEnabled -> "Bluetooth is disabled"
-                else -> "BLE advertisement not supported on this device"
+                else -> context.getString(R.string.log_advertise_unsupported)
             }
             LiveEventLogger.log(LogType.TX, "BLE Advertise failed: $reason (device=$deviceId)")
             onStopped(AdvertiseStopReason.Error)
-            return
+            return false
         }
 
         val initialData = buildAdvertiseData(config, counterSeed)
@@ -112,7 +107,7 @@ class AndroidBleAdvertiser(
                 "BLE Advertise failed: invalid payload template '${config.payload}' (device=$deviceId)",
             )
             onStopped(AdvertiseStopReason.Error)
-            return
+            return false
         }
 
         val parameters = AdvertisingSetParameters.Builder()
@@ -184,18 +179,7 @@ class AndroidBleAdvertiser(
         )
         sessionRef = session
         sessions[deviceId] = session
-
-        try {
-            advertiser.startAdvertisingSet(parameters, initialData, null, null, null, callback)
-        } catch (e: Exception) {
-            LiveEventLogger.log(
-                LogType.TX,
-                "BLE Advertise start exception: device=$deviceId, error=${e.message}",
-            )
-            sessions.remove(deviceId)
-            onStopped(AdvertiseStopReason.Error)
-            return
-        }
+        session.onCounter(session.counter)
 
         session.job = scope.launch {
             val timeoutMs = parseDurationMs(config.timeout, 15_000)
@@ -205,6 +189,7 @@ class AndroidBleAdvertiser(
                 if (repeatMs != null) {
                     while (isActive) {
                         delay(repeatMs)
+                        if (sessions[deviceId] !== session) return@withTimeoutOrNull true
                         session.counter = AdvertisePayload.nextCounter(session.counter)
                         session.onCounter(session.counter)
                         val updatedData = buildAdvertiseData(config, session.counter)
@@ -227,6 +212,19 @@ class AndroidBleAdvertiser(
                 stop(deviceId, AdvertiseStopReason.Timeout)
             }
         }
+
+        try {
+            advertiser.startAdvertisingSet(parameters, initialData, null, null, null, callback)
+        } catch (e: Exception) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise start exception: device=$deviceId, error=${e.message}",
+            )
+            stop(deviceId, AdvertiseStopReason.Error)
+            return false
+        }
+
+        return true
     }
 
     // Permission check has already been performed before session creation. Any security exception

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -13,6 +13,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import dev.eigger.hassble.R
 import dev.eigger.hassble.config.AdvertiseConfig
 import dev.eigger.hassble.config.AdvertiseModeOption
 import dev.eigger.hassble.config.AdvertiseTxPowerOption

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -2,7 +2,6 @@ package dev.eigger.hassble.ble
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertisingSet
@@ -68,6 +67,9 @@ class AndroidBleAdvertiser(
         return adapter.bluetoothLeAdvertiser
     }
 
+    // Permission check has already been performed in hasAdvertisePermission() before calling
+    // BluetoothLeAdvertiser methods. Any runtime revocation surfaces as SecurityException and is
+    // caught cleanly.
     @SuppressLint("MissingPermission")
     override fun start(
         deviceId: String,

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -1,0 +1,267 @@
+package dev.eigger.hassble.ble
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertisingSet
+import android.bluetooth.le.AdvertisingSetCallback
+import android.bluetooth.le.AdvertisingSetParameters
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import dev.eigger.hassble.config.AdvertiseConfig
+import dev.eigger.hassble.config.AdvertiseModeOption
+import dev.eigger.hassble.config.AdvertiseTxPowerOption
+import dev.eigger.hassble.config.parseDurationMs
+import dev.eigger.hassble.service.LiveEventLogger
+import dev.eigger.hassble.service.LogType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
+
+class AndroidBleAdvertiser(
+    private val context: Context,
+    private val scope: CoroutineScope,
+) : BleAdvertiser {
+
+    private class Session(
+        val config: AdvertiseConfig,
+        val callback: AdvertisingSetCallback,
+        var advertisingSet: AdvertisingSet? = null,
+        var job: Job? = null,
+        var counter: Int,
+        val onCounter: (Int) -> Unit,
+        val onStopped: (AdvertiseStopReason) -> Unit,
+        @Volatile var isStarted: Boolean = false,
+    )
+
+    private val sessions = ConcurrentHashMap<String, Session>()
+
+    private fun hasAdvertisePermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_ADMIN,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun getBluetoothAdvertiser(): BluetoothLeAdvertiser? {
+        val manager = context.getSystemService(BluetoothManager::class.java) ?: return null
+        val adapter = manager.adapter ?: return null
+        if (!adapter.isEnabled) return null
+        return adapter.bluetoothLeAdvertiser
+    }
+
+    // Permission check has already been performed in hasAdvertisePermission() before calling
+    // BluetoothLeAdvertiser methods. Any runtime revocation surfaces as SecurityException and is
+    // caught cleanly.
+    @SuppressLint("MissingPermission")
+    override fun start(
+        deviceId: String,
+        config: AdvertiseConfig,
+        counterSeed: Int,
+        onCounter: (Int) -> Unit,
+        onStopped: (AdvertiseStopReason) -> Unit,
+    ) {
+        // If already advertising for this device, stop existing session first
+        if (sessions.containsKey(deviceId)) {
+            stop(deviceId, AdvertiseStopReason.Manual)
+        }
+
+        if (!hasAdvertisePermission()) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise failed: BLUETOOTH_ADVERTISE permission not granted (device=$deviceId)",
+            )
+            onStopped(AdvertiseStopReason.Error)
+            return
+        }
+
+        val advertiser = getBluetoothAdvertiser()
+        if (advertiser == null) {
+            val manager = context.getSystemService(BluetoothManager::class.java)
+            val adapter = manager?.adapter
+            val reason = when {
+                adapter == null || !adapter.isEnabled -> "Bluetooth is disabled"
+                else -> "BLE advertisement not supported on this device"
+            }
+            LiveEventLogger.log(LogType.TX, "BLE Advertise failed: $reason (device=$deviceId)")
+            onStopped(AdvertiseStopReason.Error)
+            return
+        }
+
+        val initialData = buildAdvertiseData(config, counterSeed)
+        if (initialData == null) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise failed: invalid payload template '${config.payload}' (device=$deviceId)",
+            )
+            onStopped(AdvertiseStopReason.Error)
+            return
+        }
+
+        val parameters = AdvertisingSetParameters.Builder()
+            .setLegacyMode(true)
+            .setScannable(config.scannable)
+            .setConnectable(config.connectable)
+            .setInterval(
+                when (config.mode) {
+                    AdvertiseModeOption.low_power -> AdvertisingSetParameters.INTERVAL_HIGH
+                    AdvertiseModeOption.balanced -> AdvertisingSetParameters.INTERVAL_MEDIUM
+                    AdvertiseModeOption.low_latency -> AdvertisingSetParameters.INTERVAL_LOW
+                },
+            )
+            .setTxPowerLevel(
+                when (config.txPower) {
+                    AdvertiseTxPowerOption.ultra_low -> AdvertisingSetParameters.TX_POWER_ULTRA_LOW
+                    AdvertiseTxPowerOption.low -> AdvertisingSetParameters.TX_POWER_LOW
+                    AdvertiseTxPowerOption.medium -> AdvertisingSetParameters.TX_POWER_MEDIUM
+                    AdvertiseTxPowerOption.high -> AdvertisingSetParameters.TX_POWER_HIGH
+                },
+            )
+            .build()
+
+        var sessionRef: Session? = null
+
+        val callback = object : AdvertisingSetCallback() {
+            override fun onAdvertisingSetStarted(
+                advertisingSet: AdvertisingSet?,
+                txPower: Int,
+                status: Int,
+            ) {
+                val currentSession = sessionRef ?: return
+                if (status == ADVERTISE_SUCCESS) {
+                    currentSession.advertisingSet = advertisingSet
+                    currentSession.isStarted = true
+                    val hex = AdvertisePayload.render(config.payload, currentSession.counter)
+                    LiveEventLogger.log(
+                        LogType.TX,
+                        "BLE Advertise started: device=$deviceId, txPower=$txPower, hex=$hex",
+                    )
+                } else {
+                    val statusText = when (status) {
+                        ADVERTISE_FAILED_DATA_TOO_LARGE -> "DATA_TOO_LARGE(1)"
+                        ADVERTISE_FAILED_TOO_MANY_ADVERTISERS -> "TOO_MANY_ADVERTISERS(2)"
+                        ADVERTISE_FAILED_ALREADY_STARTED -> "ALREADY_STARTED(3)"
+                        ADVERTISE_FAILED_INTERNAL_ERROR -> "INTERNAL_ERROR(4)"
+                        ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "FEATURE_UNSUPPORTED(5)"
+                        else -> "STATUS_$status"
+                    }
+                    LiveEventLogger.log(
+                        LogType.TX,
+                        "BLE Advertise start failed: device=$deviceId, reason=$statusText",
+                    )
+                    stop(deviceId, AdvertiseStopReason.Error)
+                }
+            }
+
+            override fun onAdvertisingSetStopped(advertisingSet: AdvertisingSet?) {
+                LiveEventLogger.log(LogType.TX, "BLE Advertise stopped: device=$deviceId")
+            }
+        }
+
+        val session = Session(
+            config = config,
+            callback = callback,
+            counter = counterSeed,
+            onCounter = onCounter,
+            onStopped = onStopped,
+        )
+        sessionRef = session
+        sessions[deviceId] = session
+
+        try {
+            advertiser.startAdvertisingSet(parameters, initialData, null, null, null, callback)
+        } catch (e: Exception) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise start exception: device=$deviceId, error=${e.message}",
+            )
+            sessions.remove(deviceId)
+            onStopped(AdvertiseStopReason.Error)
+            return
+        }
+
+        session.job = scope.launch {
+            val timeoutMs = parseDurationMs(config.timeout, 15_000)
+            val repeatMs = config.repeatInterval?.let { parseDurationMs(it, 0) }?.takeIf { it > 0 }
+
+            val completedNormally = withTimeoutOrNull(timeoutMs) {
+                if (repeatMs != null) {
+                    while (isActive) {
+                        delay(repeatMs)
+                        session.counter = AdvertisePayload.nextCounter(session.counter)
+                        session.onCounter(session.counter)
+                        val updatedData = buildAdvertiseData(config, session.counter)
+                        if (updatedData != null) {
+                            val hex = AdvertisePayload.render(config.payload, session.counter)
+                            LiveEventLogger.log(
+                                LogType.TX,
+                                "BLE Advertise updated: device=$deviceId, counter=${session.counter}, hex=$hex",
+                            )
+                            runCatching {
+                                session.advertisingSet?.setAdvertisingData(updatedData)
+                            }
+                        }
+                    }
+                } else {
+                    awaitCancellation()
+                }
+            }
+            if (completedNormally == null) {
+                stop(deviceId, AdvertiseStopReason.Timeout)
+            }
+        }
+    }
+
+    // Permission check has already been performed before session creation. Any security exception
+    // when stopping is ignored cleanly.
+    @SuppressLint("MissingPermission")
+    override fun stop(deviceId: String, reason: AdvertiseStopReason) {
+        val session = sessions.remove(deviceId) ?: return
+        session.job?.cancel()
+        session.job = null
+
+        val advertiser = getBluetoothAdvertiser()
+        if (advertiser != null && (session.advertisingSet != null || session.isStarted)) {
+            runCatching { advertiser.stopAdvertisingSet(session.callback) }
+        }
+        session.onStopped(reason)
+    }
+
+    override fun stopAll() {
+        val keys = sessions.keys().toList()
+        for (key in keys) {
+            stop(key, AdvertiseStopReason.Shutdown)
+        }
+    }
+
+    override fun isAdvertising(deviceId: String): Boolean {
+        return sessions.containsKey(deviceId)
+    }
+
+    private fun buildAdvertiseData(config: AdvertiseConfig, counter: Int): AdvertiseData? {
+        val renderedHex = AdvertisePayload.render(config.payload, counter)
+        val bytes = AdvertisePayload.toBytes(renderedHex) ?: return null
+        return AdvertiseData.Builder()
+            .addManufacturerData(config.manufacturerId, bytes)
+            .setIncludeDeviceName(config.includeDeviceName)
+            .setIncludeTxPowerLevel(false)
+            .build()
+    }
+}

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -715,9 +715,8 @@ class BleRuntime(
         onAdvertisingChanged(d.id, isAdvertising)
         val stateStr = if (isAdvertising) "on" else "off"
         val targetInstanceIds = if (isDynamicAdvertisement(d)) {
-            val macRegex = Regex("^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
             declaredAdvInstances.filter {
-                it == d.id || (it.startsWith("${d.id}_") && macRegex.matches(it.substring(d.id.length + 1)))
+                it == d.id || (it.startsWith("${d.id}_") && NORMALIZED_MAC_REGEX.matches(it.substring(d.id.length + 1)))
             }.ifEmpty { listOf(d.id) }
         } else {
             listOf(d.id)
@@ -873,4 +872,8 @@ class BleRuntime(
             val fmt = m.groupValues[1]
             if (fmt.isEmpty()) value.toInt().toString() else String.format("%$fmt", value.toInt())
         }
+
+    companion object {
+        private val NORMALIZED_MAC_REGEX = Regex("^[0-9A-F]{12}$", RegexOption.IGNORE_CASE)
+    }
 }

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -683,10 +683,10 @@ class BleRuntime(
 
     private fun startAdvertise(d: DeviceConfig) {
         val advConfig = d.advertise ?: return
-        val errKeys = ConfigValidator.errorKeys(validationIssues, d.id)
-        if (d.id in errKeys) return
-        val seed = advCounters[d.id] ?: 0
-        advertiser?.start(
+        if (ConfigValidator.hasDeviceError(validationIssues, d.id)) return
+        val currentCounter = advCounters[d.id]
+        val seed = if (currentCounter != null) AdvertisePayload.nextCounter(currentCounter) else 0
+        val started = advertiser?.start(
             deviceId = d.id,
             config = advConfig,
             counterSeed = seed,
@@ -697,14 +697,21 @@ class BleRuntime(
             onStopped = { _ ->
                 publishAdvertisingState(d, false)
             },
-        )
-        publishAdvertisingState(d, true)
+        ) ?: false
+        if (started) {
+            publishAdvertisingState(d, true)
+        }
     }
 
     private fun publishAdvertisingState(d: DeviceConfig, isAdvertising: Boolean) {
         onAdvertisingChanged(d.id, isAdvertising)
         val stateStr = if (isAdvertising) "on" else "off"
-        ws.sendStates(listOf("${d.id}_advertising" to stateStr))
+        val targetInstanceIds = if (isDynamicAdvertisement(d)) {
+            declaredAdvInstances.filter { it == d.id || it.startsWith("${d.id}_") }.ifEmpty { listOf(d.id) }
+        } else {
+            listOf(d.id)
+        }
+        ws.sendStates(targetInstanceIds.map { "${it}_advertising" to stateStr })
     }
 
     /** 게이트웨이 실행 중 특정 기기의 BLE 광고 송신을 시작. */

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -716,10 +716,8 @@ class BleRuntime(
 
     /** 게이트웨이 실행 중 특정 기기의 BLE 광고 송신을 시작. */
     fun triggerAdvertise(deviceId: String) {
-        val d = devices[deviceId]
-            ?: if (::config.isInitialized) config.devices.firstOrNull { it.id == deviceId } else null
-            ?: lastConfig?.devices?.firstOrNull { it.id == deviceId }
-            ?: return
+        if (!::config.isInitialized) return
+        val d = devices[deviceId] ?: config.devices.firstOrNull { it.id == deviceId } ?: return
         startAdvertise(d)
     }
 

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -1,6 +1,7 @@
 package dev.eigger.hassble.ble
 
 import dev.eigger.hassble.service.BleGatewayService
+import dev.eigger.hassble.config.AdvertiseCounterMode
 import dev.eigger.hassble.config.AdvertisementInstanceMode
 import dev.eigger.hassble.config.effectiveStateClass
 import dev.eigger.hassble.config.BleScanModeOption
@@ -684,15 +685,22 @@ class BleRuntime(
     private fun startAdvertise(d: DeviceConfig) {
         val advConfig = d.advertise ?: return
         if (ConfigValidator.hasDeviceError(validationIssues, d.id)) return
-        val currentCounter = advCounters[d.id]
-        val seed = if (currentCounter != null) AdvertisePayload.nextCounter(currentCounter) else 0
+        val seed = when (advConfig.counterMode) {
+            AdvertiseCounterMode.reset -> advConfig.counterStart and 0xFF
+            AdvertiseCounterMode.persist -> {
+                val current = advCounters[d.id]
+                if (current != null) AdvertisePayload.nextCounter(current) else (advConfig.counterStart and 0xFF)
+            }
+        }
         val started = advertiser?.start(
             deviceId = d.id,
             config = advConfig,
             counterSeed = seed,
             onCounter = { newCounter ->
-                advCounters = advCounters + (d.id to newCounter)
-                onAdvCounterChanged(d.id, newCounter)
+                if (advConfig.counterMode == AdvertiseCounterMode.persist) {
+                    advCounters = advCounters + (d.id to newCounter)
+                    onAdvCounterChanged(d.id, newCounter)
+                }
             },
             onStopped = { _ ->
                 publishAdvertisingState(d, false)
@@ -707,7 +715,10 @@ class BleRuntime(
         onAdvertisingChanged(d.id, isAdvertising)
         val stateStr = if (isAdvertising) "on" else "off"
         val targetInstanceIds = if (isDynamicAdvertisement(d)) {
-            declaredAdvInstances.filter { it == d.id || it.startsWith("${d.id}_") }.ifEmpty { listOf(d.id) }
+            val macRegex = Regex("^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+            declaredAdvInstances.filter {
+                it == d.id || (it.startsWith("${d.id}_") && macRegex.matches(it.substring(d.id.length + 1)))
+            }.ifEmpty { listOf(d.id) }
         } else {
             listOf(d.id)
         }

--- a/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BleRuntime.kt
@@ -5,6 +5,7 @@ import dev.eigger.hassble.config.AdvertisementInstanceMode
 import dev.eigger.hassble.config.effectiveStateClass
 import dev.eigger.hassble.config.BleScanModeOption
 import dev.eigger.hassble.config.ConfigValidator
+import dev.eigger.hassble.config.ControlAction
 import dev.eigger.hassble.config.ControlConfig
 import dev.eigger.hassble.config.DeviceConfig
 import dev.eigger.hassble.config.GatewayConfig
@@ -50,10 +51,13 @@ class BleRuntime(
     private val scanner: AdvertisementScanner,
     private val gatt: GattNotifySource,
     private val obd: Elm327Source,
+    private val advertiser: BleAdvertiser? = null,
     private val onDiscoveredAdvChanged: (List<DiscoveredAdvInstance>) -> Unit = {},
     private val onSensorValuesChanged: (List<SensorLastValue>) -> Unit = {},
     private val onLinkDataReceived: (String, Long) -> Unit = { _, _ -> },
     private val onLinkStatus: (DeviceLinkStatus) -> Unit = {},
+    private val onAdvCounterChanged: (String, Int) -> Unit = { _, _ -> },
+    private val onAdvertisingChanged: (String, Boolean) -> Unit = { _, _ -> },
 ) {
     private val json = Json { ignoreUnknownKeys = true }
     private var scanJob: Job? = null
@@ -65,6 +69,7 @@ class BleRuntime(
     private var scanMode: BleScanModeOption = BleScanModeOption.BALANCED
     private var autoConnectDisabledIds: Set<String> = emptySet()
     private var unfilteredScan: Boolean = false
+    private var advCounters: Map<String, Int> = emptyMap()
 
     // Cached states for change tracking between apply() calls
     private var lastConfig: GatewayConfig? = null
@@ -120,7 +125,8 @@ class BleRuntime(
         boundDevices: Map<String, String>,
         scanMode: BleScanModeOption = BleScanModeOption.BALANCED,
         autoConnectDisabledIds: Set<String> = emptySet(),
-        unfilteredScan: Boolean = false
+        unfilteredScan: Boolean = false,
+        advCounters: Map<String, Int> = emptyMap(),
     ) {
         val oldConfig = this.lastConfig
         val oldEnabled = this.lastEnabled
@@ -137,6 +143,7 @@ class BleRuntime(
         this.scanMode = scanMode
         this.autoConnectDisabledIds = autoConnectDisabledIds
         this.unfilteredScan = unfilteredScan
+        this.advCounters = advCounters
 
         if (oldConfig == null) {
             // First run: complete initialization
@@ -273,6 +280,16 @@ class BleRuntime(
             ws.sendStates(listOf("${instanceId}_link_status" to if (isConnected) "on" else "off"))
         }
 
+        if (d.advertise != null) {
+            ws.declareEntity(EntityMsg(
+                id = 0, uniqueId = "${instanceId}_advertising", platform = "binary_sensor",
+                name = "Advertising", device = ref,
+                entityCategory = "diagnostic",
+            ))
+            val isAdv = advertiser?.isAdvertising(d.id) == true
+            ws.sendStates(listOf("${instanceId}_advertising" to if (isAdv) "on" else "off"))
+        }
+
         val errorKeys = ConfigValidator.errorKeys(validationIssues, d.id)
         for (s in d.sensors) {
             if (!isEnabled(d.id, s.key)) continue
@@ -320,6 +337,7 @@ class BleRuntime(
     private fun stopDevice(deviceId: String) {
         deviceConnectionJobs[deviceId]?.cancel()
         deviceConnectionJobs.remove(deviceId)
+        advertiser?.stop(deviceId, AdvertiseStopReason.Shutdown)
 
         val d = devices[deviceId]
         if (d != null) {
@@ -495,6 +513,9 @@ class BleRuntime(
         when (d.source) {
             Source.advertisement -> {
                 val mac = r.macAddress ?: return
+                if (d.advertise?.stopOnResponse == true && advertiser?.isAdvertising(d.id) == true) {
+                    advertiser.stop(d.id, AdvertiseStopReason.ResponseReceived)
+                }
                 if (isDynamicAdvertisement(d)) {
                     ensureAdvertisementInstance(d, mac, r.deviceName)
                 }
@@ -587,6 +608,20 @@ class BleRuntime(
         if (event["kind"]?.jsonPrimitive?.content != "command") return
         val cmd = json.decodeFromJsonElement(CommandPayload.serializer(), event)
         val (d, c) = controls[cmd.uniqueId] ?: return
+        when (c.action) {
+            ControlAction.advertise -> {
+                when (cmd.action) {
+                    "press", "turn_on" -> startAdvertise(d)
+                    "turn_off" -> stopAdvertise(d.id)
+                }
+                return
+            }
+            ControlAction.stop_advertise -> {
+                stopAdvertise(d.id)
+                return
+            }
+            null -> {}
+        }
         val prim = cmd.value as? JsonPrimitive
         val hex = when (cmd.action) {
             "turn_on" -> c.command["on"]
@@ -646,6 +681,48 @@ class BleRuntime(
         onLinkStatus(DeviceLinkStatus(deviceId, DeviceLinkState.Disconnected, mac))
     }
 
+    private fun startAdvertise(d: DeviceConfig) {
+        val advConfig = d.advertise ?: return
+        val errKeys = ConfigValidator.errorKeys(validationIssues, d.id)
+        if (d.id in errKeys) return
+        val seed = advCounters[d.id] ?: 0
+        advertiser?.start(
+            deviceId = d.id,
+            config = advConfig,
+            counterSeed = seed,
+            onCounter = { newCounter ->
+                advCounters = advCounters + (d.id to newCounter)
+                onAdvCounterChanged(d.id, newCounter)
+            },
+            onStopped = { _ ->
+                publishAdvertisingState(d, false)
+            },
+        )
+        publishAdvertisingState(d, true)
+    }
+
+    private fun publishAdvertisingState(d: DeviceConfig, isAdvertising: Boolean) {
+        onAdvertisingChanged(d.id, isAdvertising)
+        val stateStr = if (isAdvertising) "on" else "off"
+        ws.sendStates(listOf("${d.id}_advertising" to stateStr))
+    }
+
+    /** 게이트웨이 실행 중 특정 기기의 BLE 광고 송신을 시작. */
+    fun triggerAdvertise(deviceId: String) {
+        val d = devices[deviceId]
+            ?: if (::config.isInitialized) config.devices.firstOrNull { it.id == deviceId } else null
+            ?: lastConfig?.devices?.firstOrNull { it.id == deviceId }
+            ?: return
+        startAdvertise(d)
+    }
+
+    /** 게이트웨이 실행 중 특정 기기의 BLE 광고 송신을 중단. */
+    fun stopAdvertise(deviceId: String) {
+        advertiser?.stop(deviceId, AdvertiseStopReason.Manual)
+    }
+
+    fun isAdvertising(deviceId: String): Boolean = advertiser?.isAdvertising(deviceId) == true
+
     fun stop() {
         scanJob?.cancel()
         scanJob = null
@@ -663,6 +740,7 @@ class BleRuntime(
         }
 
         scanner.stop()
+        advertiser?.stopAll()
         discoveredAdvInstances.clear()
         publishDiscoveredAdv()
         lastSensorValues.clear()

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -143,6 +143,7 @@ data class ControlConfig(
 
 enum class ControlType { switch, number, select, button }
 enum class ControlAction { advertise, stop_advertise }
+enum class AdvertiseCounterMode { reset, persist }
 
 /**
  * 광고 송신(TX) 설정. advertisement 소스 전용.
@@ -152,6 +153,8 @@ enum class ControlAction { advertise, stop_advertise }
 data class AdvertiseConfig(
     @SerialName("manufacturer_id") val manufacturerId: Int,
     val payload: String,
+    @SerialName("counter_mode") val counterMode: AdvertiseCounterMode = AdvertiseCounterMode.reset,
+    @SerialName("counter_start") val counterStart: Int = 0,
     val mode: AdvertiseModeOption = AdvertiseModeOption.balanced,
     @SerialName("tx_power") val txPower: AdvertiseTxPowerOption = AdvertiseTxPowerOption.high,
     val timeout: String = "15s",

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -32,6 +32,7 @@ data class DeviceConfig(
     val source: Source,
     val match: MatchConfig? = null,
     @SerialName("instance_mode") val instanceMode: AdvertisementInstanceMode = AdvertisementInstanceMode.mac,
+    val advertise: AdvertiseConfig? = null,
     val gatt: GattConfig? = null,
     val obd: ObdConfig? = null,
     val sensors: List<SensorConfig> = emptyList(),
@@ -128,6 +129,8 @@ data class ControlConfig(
     val name: String? = null,
     val icon: String? = null,
     @SerialName("entity_category") val entityCategory: String? = null,
+    /** 지정하면 command(hex write) 대신 앱 내부 동작을 수행한다. */
+    val action: ControlAction? = null,
     // command 매핑:
     //  switch → {on, off} hex / number → {template} ("A1{value:02X}")
     //  select → {<option>: hex, ...} / button → {press: hex}
@@ -139,6 +142,30 @@ data class ControlConfig(
 )
 
 enum class ControlType { switch, number, select, button }
+enum class ControlAction { advertise, stop_advertise }
+
+/**
+ * 광고 송신(TX) 설정. advertisement 소스 전용.
+ * payload는 manufacturer payload(company ID 제외) hex이며 {counter} / {counter:02X} 토큰을 쓸 수 있다.
+ */
+@Serializable
+data class AdvertiseConfig(
+    @SerialName("manufacturer_id") val manufacturerId: Int,
+    val payload: String,
+    val mode: AdvertiseModeOption = AdvertiseModeOption.balanced,
+    @SerialName("tx_power") val txPower: AdvertiseTxPowerOption = AdvertiseTxPowerOption.high,
+    val timeout: String = "15s",
+    /** 지정하면 이 주기마다 payload를 갱신(=counter 증가). 생략하면 누름당 1회만 세팅. */
+    @SerialName("repeat_interval") val repeatInterval: String? = null,
+    /** 이 device의 match에 걸리는 광고를 수신하면 즉시 송신 중단. */
+    @SerialName("stop_on_response") val stopOnResponse: Boolean = true,
+    val connectable: Boolean = false,
+    val scannable: Boolean = true,
+    @SerialName("include_device_name") val includeDeviceName: Boolean = false,
+)
+
+enum class AdvertiseModeOption { low_power, balanced, low_latency }
+enum class AdvertiseTxPowerOption { ultra_low, low, medium, high }
 
 enum class BleScanModeOption(val label: String) {
     LOW_POWER("Low Power"),

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -1,5 +1,7 @@
 package dev.eigger.hassble.config
 
+import dev.eigger.hassble.ble.AdvertisePayload
+
 enum class ValidationLevel { WARNING, ERROR }
 
 data class ValidationIssue(
@@ -22,6 +24,11 @@ object ConfigValidator {
 
     private fun controlPath(deviceId: String, controlKey: String, field: String? = null): String {
         val base = "devices[$deviceId].controls[$controlKey]"
+        return if (field != null) "$base.$field" else base
+    }
+
+    private fun devicePath(deviceId: String, field: String? = null): String {
+        val base = "devices[$deviceId]"
         return if (field != null) "$base.$field" else base
     }
 
@@ -132,30 +139,74 @@ object ConfigValidator {
                     sensorPath(id, key, "decode"))
         }
 
+        // ── advertise 검증 ────────────────────────────────────────────────────────
+        if (device.advertise != null) {
+            val id = device.id
+            if (device.source != Source.advertisement) {
+                issues += ValidationIssue(
+                    ValidationLevel.ERROR, id, null,
+                    "'advertise' is only supported for source: advertisement",
+                    devicePath(id, "advertise")
+                )
+            }
+            val payloadErr = AdvertisePayload.validationError(device.advertise.payload)
+            if (payloadErr != null) {
+                issues += ValidationIssue(
+                    ValidationLevel.ERROR, id, null,
+                    payloadErr,
+                    devicePath(id, "advertise.payload")
+                )
+            }
+            if (device.instanceMode == AdvertisementInstanceMode.mac && device.match?.mac.isNullOrBlank()) {
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "advertise with instance_mode: mac creates one button per discovered MAC — use instance_mode: shared",
+                    devicePath(id, "instance_mode")
+                )
+            }
+            if (device.controls.none { it.action == ControlAction.advertise }) {
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "'advertise' block has no control with action: advertise — it can only be triggered from the app",
+                    devicePath(id, "advertise")
+                )
+            }
+        }
+
         // ── 컨트롤 검증 ────────────────────────────────────────────────────────
         for (c in device.controls) {
             val id = device.id
             val key = c.key
-            if (device.source == Source.gatt_notify && device.gatt?.writeCharUuid.isNullOrBlank())
-                issues += ValidationIssue(ValidationLevel.ERROR, id, key,
-                    "control requires write_char_uuid in gatt config — control will be skipped",
-                    controlPath(id, key, "command"))
-            if (device.source == Source.obd && device.obd?.txCharUuid.isNullOrBlank())
-                issues += ValidationIssue(ValidationLevel.ERROR, id, key,
-                    "control requires tx_char_uuid in obd config — control will be skipped",
-                    controlPath(id, key, "command"))
+            if (c.action != null) {
+                if (device.advertise == null) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, key,
+                        "control action '${c.action}' requires an 'advertise' block on the device",
+                        controlPath(id, key, "action")
+                    )
+                }
+            } else {
+                if (device.source == Source.gatt_notify && device.gatt?.writeCharUuid.isNullOrBlank())
+                    issues += ValidationIssue(ValidationLevel.ERROR, id, key,
+                        "control requires write_char_uuid in gatt config — control will be skipped",
+                        controlPath(id, key, "command"))
+                if (device.source == Source.obd && device.obd?.txCharUuid.isNullOrBlank())
+                    issues += ValidationIssue(ValidationLevel.ERROR, id, key,
+                        "control requires tx_char_uuid in obd config — control will be skipped",
+                        controlPath(id, key, "command"))
 
-            // 컨트롤 타입별 필수 command 키 검증
-            val missingKeys = when (c.type) {
-                ControlType.switch -> listOf("on", "off").filter { it !in c.command }
-                ControlType.button -> listOf("press").filter { it !in c.command }
-                ControlType.number -> listOf("template").filter { it !in c.command }
-                ControlType.select -> c.options.filter { it !in c.command }
+                // 컨트롤 타입별 필수 command 키 검증
+                val missingKeys = when (c.type) {
+                    ControlType.switch -> listOf("on", "off").filter { it !in c.command }
+                    ControlType.button -> listOf("press").filter { it !in c.command }
+                    ControlType.number -> listOf("template").filter { it !in c.command }
+                    ControlType.select -> c.options.filter { it !in c.command }
+                }
+                if (missingKeys.isNotEmpty())
+                    issues += ValidationIssue(ValidationLevel.ERROR, id, key,
+                        "control type '${c.type}' missing command key(s): $missingKeys — control will not work",
+                        controlPath(id, key, "command"))
             }
-            if (missingKeys.isNotEmpty())
-                issues += ValidationIssue(ValidationLevel.ERROR, id, key,
-                    "control type '${c.type}' missing command key(s): $missingKeys — control will not work",
-                    controlPath(id, key, "command"))
         }
 
         return issues
@@ -178,7 +229,7 @@ object ConfigValidator {
         val oldControls = oldD.controls.associateBy { it.key }
         val newControls = newD.controls.associateBy { it.key }
         if ((oldControls.keys - newControls.keys).isNotEmpty()) return true
-        if (newControls.any { (key, c) -> oldControls[key]?.type != c.type }) return true
+        if (newControls.any { (key, c) -> oldControls[key]?.type != c.type || oldControls[key]?.action != c.action }) return true
         return false
     }
 
@@ -206,7 +257,7 @@ object ConfigValidator {
         }
         for (c in d.controls) {
             if (c.key in errKeys) continue
-            sb.append("C|${c.key}|${c.type}\n")
+            sb.append("C|${c.key}|${c.type}|${c.action}\n")
         }
         return sb.toString()
     }

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -157,6 +157,13 @@ object ConfigValidator {
                     devicePath(id, "advertise.payload")
                 )
             }
+            if (device.advertise.counterStart !in 0..255) {
+                issues += ValidationIssue(
+                    ValidationLevel.ERROR, id, null,
+                    "counter_start must be between 0 and 255 (got ${device.advertise.counterStart})",
+                    devicePath(id, "advertise.counter_start")
+                )
+            }
             if (device.instanceMode == AdvertisementInstanceMode.mac && device.match?.mac.isNullOrBlank()) {
                 issues += ValidationIssue(
                     ValidationLevel.WARNING, id, null,

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -178,6 +178,13 @@ object ConfigValidator {
                     devicePath(id, "advertise")
                 )
             }
+            if (device.advertise.includeDeviceName) {
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "include_device_name: true includes device name in advertising data, which may exceed the 31-byte legacy BLE limit",
+                    devicePath(id, "advertise.include_device_name")
+                )
+            }
         }
 
         // ── 컨트롤 검증 ────────────────────────────────────────────────────────

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -217,6 +217,10 @@ object ConfigValidator {
         issues.filter { it.level == ValidationLevel.ERROR && it.deviceId == deviceId && it.sensorKey != null }
             .mapNotNull { it.sensorKey }.toSet()
 
+    /** 기기 수준(sensorKey == null)의 ERROR 이슈 존재 여부. */
+    fun hasDeviceError(issues: List<ValidationIssue>, deviceId: String): Boolean =
+        issues.any { it.level == ValidationLevel.ERROR && it.deviceId == deviceId && it.sensorKey == null }
+
     /**
      * 센서/컨트롤의 구조적 변경(platform/type 변경, 항목 삭제) 여부 반환.
      * HA 엔티티 타입 불일치가 예상될 때 true → 기존 HA 엔티티를 삭제하고 재선언해야 함.

--- a/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/HassSettingsRepository.kt
@@ -46,6 +46,7 @@ class HassSettingsRepository(private val context: Context) {
         private val KEY_PENDING_HA_REMOVAL_MODES = stringPreferencesKey("pending_ha_removal_modes")
         private val KEY_EXCLUDED_DEVICES = stringPreferencesKey("excluded_devices")
         private val KEY_LOG_BUFFER_LIMIT = intPreferencesKey("log_buffer_limit")
+        private val KEY_ADV_COUNTERS = stringPreferencesKey("adv_counters")
     }
 
     val haUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -84,6 +85,13 @@ class HassSettingsRepository(private val context: Context) {
         val jsonStr = prefs[KEY_BOUND_DEVICES] ?: return@map emptyMap()
         runCatching {
             json.decodeFromString(MapSerializer(String.serializer(), String.serializer()), jsonStr)
+        }.getOrDefault(emptyMap())
+    }
+
+    val advCounters: Flow<Map<String, Int>> = context.dataStore.data.map { prefs ->
+        val jsonStr = prefs[KEY_ADV_COUNTERS] ?: return@map emptyMap()
+        runCatching {
+            json.decodeFromString(MapSerializer(String.serializer(), Int.serializer()), jsonStr)
         }.getOrDefault(emptyMap())
     }
 
@@ -459,6 +467,14 @@ class HassSettingsRepository(private val context: Context) {
                 }
             }
 
+            prefs[KEY_ADV_COUNTERS]?.let { raw ->
+                val map = runCatching { json.decodeFromString(MapSerializer(String.serializer(), Int.serializer()), raw) }
+                    .getOrDefault(emptyMap()).toMutableMap()
+                if (map.remove(deviceId) != null) {
+                    prefs[KEY_ADV_COUNTERS] = json.encodeToString(MapSerializer(String.serializer(), Int.serializer()), map)
+                }
+            }
+
             prefs[KEY_ENTITY_FINGERPRINTS]?.let { raw ->
                 val map = runCatching { json.decodeFromString(stringMap, raw) }
                     .getOrDefault(emptyMap()).toMutableMap()
@@ -535,6 +551,19 @@ class HassSettingsRepository(private val context: Context) {
             currentMap.remove(deviceId)
             val newJson = json.encodeToString(MapSerializer(String.serializer(), String.serializer()), currentMap)
             prefs[KEY_BOUND_DEVICES] = newJson
+        }
+    }
+
+    suspend fun saveAdvCounter(deviceId: String, value: Int) {
+        context.dataStore.edit { prefs ->
+            val currentJson = prefs[KEY_ADV_COUNTERS] ?: "{}"
+            val currentMap = runCatching {
+                json.decodeFromString(MapSerializer(String.serializer(), Int.serializer()), currentJson)
+            }.getOrDefault(emptyMap()).toMutableMap()
+
+            currentMap[deviceId] = value
+            val newJson = json.encodeToString(MapSerializer(String.serializer(), Int.serializer()), currentMap)
+            prefs[KEY_ADV_COUNTERS] = newJson
         }
     }
 

--- a/app/src/main/java/dev/eigger/hassble/decode/Decoder.kt
+++ b/app/src/main/java/dev/eigger/hassble/decode/Decoder.kt
@@ -15,12 +15,16 @@ import java.util.Calendar
 object Decoder {
 
     fun decodeStructured(bytes: ByteArray, c: DecodeConfig): Any? {
-        if (c.offset + c.length > bytes.size) return null
         if (c.type == DataType.timestamp) return decodeTimestamp(bytes, c.offset)
         if (c.type == DataType.string) {
-            val slice = bytes.copyOfRange(c.offset, c.offset + c.length)
-            return slice.map { (it.toInt() and 0xFF).toChar() }.joinToString("")
+            val end = if (c.length <= 0) bytes.size else minOf(c.offset + c.length, bytes.size)
+            if (c.offset >= end) return null
+            return bytes.copyOfRange(c.offset, end)
+                .map { (it.toInt() and 0xFF).toChar() }
+                .joinToString("")
+                .trimEnd(' ', '\u0000')
         }
+        if (c.offset + c.length > bytes.size) return null
         val slice = bytes.copyOfRange(c.offset, c.offset + c.length)
         var raw = toLong(slice, c.type, c.endian)
         c.bitmask?.let { raw = raw and it }

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -49,6 +49,7 @@ private data class SettingsSnapshot(
     val scanMode: dev.eigger.hassble.config.BleScanModeOption,
     val autoConnectDisabled: Set<String>,
     val unfilteredScan: Boolean,
+    val advCounters: Map<String, Int> = emptyMap(),
 )
 
 class BleGatewayService : Service() {
@@ -116,6 +117,18 @@ class BleGatewayService : Service() {
         if (intent?.action == ACTION_DISCONNECT_DEVICE) {
             val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
             runtime?.disconnectDevice(deviceId)
+            return START_STICKY
+        }
+
+        if (intent?.action == ACTION_TRIGGER_ADVERTISE) {
+            val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            runtime?.triggerAdvertise(deviceId)
+            return START_STICKY
+        }
+
+        if (intent?.action == ACTION_STOP_ADVERTISE) {
+            val deviceId = intent.getStringExtra(EXTRA_DEVICE_ID) ?: return START_STICKY
+            runtime?.stopAdvertise(deviceId)
             return START_STICKY
         }
 
@@ -330,12 +343,14 @@ class BleGatewayService : Service() {
                 val obdSource = dev.eigger.hassble.ble.NordicElm327Source(
                     this@BleGatewayService, onLinkStatus,
                 )
+                val advertiser = dev.eigger.hassble.ble.AndroidBleAdvertiser(this@BleGatewayService, scope)
                 runtime = BleRuntime(
                     scope,
                     ws!!,
                     scanner,
                     gattSource,
                     obdSource,
+                    advertiser = advertiser,
                     onDiscoveredAdvChanged = { _discoveredAdvInstances.value = it },
                     onSensorValuesChanged = { _sensorLastValues.value = it },
                     onLinkDataReceived = { profileId, ts ->
@@ -345,17 +360,27 @@ class BleGatewayService : Service() {
                         }
                     },
                     onLinkStatus = onLinkStatus,
+                    onAdvCounterChanged = { id, value ->
+                        scope.launch { repository.saveAdvCounter(id, value) }
+                    },
+                    onAdvertisingChanged = { id, isAdv ->
+                        val cur = _advertisingDeviceIds.value
+                        _advertisingDeviceIds.value = if (isAdv) cur + id else cur - id
+                    },
                 ).also { it.start() }
             }
 
             settingsJob = scope.launch {
                 combine(
-                    repository.boundDevices,
-                    repository.enabledSensors,
-                    repository.enabledSensorsInitialized,
-                    repository.scanMode,
-                    repository.autoConnectDisabled,
-                    LiveEventLogger.includeAdvLogsFlow,
+                    listOf(
+                        repository.boundDevices,
+                        repository.enabledSensors,
+                        repository.enabledSensorsInitialized,
+                        repository.scanMode,
+                        repository.autoConnectDisabled,
+                        LiveEventLogger.includeAdvLogsFlow,
+                        repository.advCounters,
+                    )
                 ) { args ->
                     val boundMap = args[0] as Map<*, *>
                     val enabledSensors = args[1] as Set<*>
@@ -363,6 +388,7 @@ class BleGatewayService : Service() {
                     val scanMode = args[3] as dev.eigger.hassble.config.BleScanModeOption
                     val autoConnectDisabled = args[4] as Set<*>
                     val unfilteredScan = args[5] as Boolean
+                    val advCounters = args[6] as Map<*, *>
                     val effectiveEnabled = if (!initialized) defaultEnabled else enabledSensors.filterIsInstance<String>().toSet()
                     SettingsSnapshot(
                         boundMap = boundMap.entries.associate { it.key.toString() to it.value.toString() },
@@ -370,6 +396,7 @@ class BleGatewayService : Service() {
                         scanMode = scanMode,
                         autoConnectDisabled = autoConnectDisabled.filterIsInstance<String>().toSet(),
                         unfilteredScan = unfilteredScan,
+                        advCounters = advCounters.entries.associate { it.key.toString() to ((it.value as? Number)?.toInt() ?: 0) },
                     )
                 }.collect { snapshot ->
                     runtime?.apply(
@@ -379,6 +406,7 @@ class BleGatewayService : Service() {
                         snapshot.scanMode,
                         snapshot.autoConnectDisabled,
                         snapshot.unfilteredScan,
+                        snapshot.advCounters,
                     )
                 }
             }
@@ -445,6 +473,7 @@ class BleGatewayService : Service() {
         _discoveredAdvInstances.value = emptyList()
         _sensorLastValues.value = emptyList()
         _deviceLinkStatuses.value = emptyList()
+        _advertisingDeviceIds.value = emptySet()
         _serviceError.value = null
         _usingCachedConfig.value = false
         scope.cancel()
@@ -556,7 +585,8 @@ class BleGatewayService : Service() {
         private const val ACTION_SET_AUTO_CONNECT = "dev.eigger.hassble.SET_AUTO_CONNECT"
         private const val EXTRA_AUTO_CONNECT = "auto_connect"
         private const val ACTION_CONNECT_DEVICE = "dev.eigger.hassble.CONNECT_DEVICE"
-        private const val ACTION_DISCONNECT_DEVICE = "dev.eigger.hassble.DISCONNECT_DEVICE"
+        private const val ACTION_TRIGGER_ADVERTISE = "dev.eigger.hassble.TRIGGER_ADVERTISE"
+        private const val ACTION_STOP_ADVERTISE = "dev.eigger.hassble.STOP_ADVERTISE"
 
         private val _serviceConnectionState = MutableStateFlow(ConnectionState.Disconnected)
         val serviceConnectionState: StateFlow<ConnectionState> = _serviceConnectionState.asStateFlow()
@@ -575,6 +605,9 @@ class BleGatewayService : Service() {
 
         private val _deviceLinkStatuses = MutableStateFlow<List<DeviceLinkStatus>>(emptyList())
         val deviceLinkStatuses: StateFlow<List<DeviceLinkStatus>> = _deviceLinkStatuses.asStateFlow()
+
+        private val _advertisingDeviceIds = MutableStateFlow<Set<String>>(emptySet())
+        val advertisingDeviceIds: StateFlow<Set<String>> = _advertisingDeviceIds.asStateFlow()
 
         private val _serviceError = MutableStateFlow<String?>(null)
         val serviceError: StateFlow<String?> = _serviceError.asStateFlow()
@@ -625,6 +658,18 @@ class BleGatewayService : Service() {
         fun disconnectDevice(context: Context, deviceId: String) {
             context.startService(Intent(context, BleGatewayService::class.java)
                 .setAction(ACTION_DISCONNECT_DEVICE)
+                .putExtra(EXTRA_DEVICE_ID, deviceId))
+        }
+
+        fun triggerAdvertise(context: Context, deviceId: String) {
+            context.startService(Intent(context, BleGatewayService::class.java)
+                .setAction(ACTION_TRIGGER_ADVERTISE)
+                .putExtra(EXTRA_DEVICE_ID, deviceId))
+        }
+
+        fun stopAdvertise(context: Context, deviceId: String) {
+            context.startService(Intent(context, BleGatewayService::class.java)
+                .setAction(ACTION_STOP_ADVERTISE)
                 .putExtra(EXTRA_DEVICE_ID, deviceId))
         }
     }

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -585,6 +585,7 @@ class BleGatewayService : Service() {
         private const val ACTION_SET_AUTO_CONNECT = "dev.eigger.hassble.SET_AUTO_CONNECT"
         private const val EXTRA_AUTO_CONNECT = "auto_connect"
         private const val ACTION_CONNECT_DEVICE = "dev.eigger.hassble.CONNECT_DEVICE"
+        private const val ACTION_DISCONNECT_DEVICE = "dev.eigger.hassble.DISCONNECT_DEVICE"
         private const val ACTION_TRIGGER_ADVERTISE = "dev.eigger.hassble.TRIGGER_ADVERTISE"
         private const val ACTION_STOP_ADVERTISE = "dev.eigger.hassble.STOP_ADVERTISE"
 

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -358,6 +358,7 @@ private fun HomeScreen() {
     val logBufferLimit by repository.logBufferLimit.collectAsState(initial = LiveEventLogger.DEFAULT_MAX_LOGS)
     val discoveredAdv by BleGatewayService.discoveredAdvInstances.collectAsState()
     val sensorLastValues by BleGatewayService.sensorLastValues.collectAsState()
+    val advertisingDeviceIds by BleGatewayService.advertisingDeviceIds.collectAsState()
 
     LaunchedEffect(logBufferLimit) {
         LiveEventLogger.setMaxLogs(logBufferLimit)
@@ -465,6 +466,7 @@ private fun HomeScreen() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             add(Manifest.permission.BLUETOOTH_SCAN)
             add(Manifest.permission.BLUETOOTH_CONNECT)
+            add(Manifest.permission.BLUETOOTH_ADVERTISE)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             add(Manifest.permission.POST_NOTIFICATIONS)
@@ -638,6 +640,7 @@ private fun HomeScreen() {
                     discoveredAdv = discoveredAdv,
                     sensorLastValues = sensorLastValues,
                     deviceLinkStatuses = deviceLinkStatuses,
+                    advertisingDeviceIds = advertisingDeviceIds,
                     gitRepoInput = gitRepoInput,
                     gitBranchInput = gitBranchInput,
                     gitTokenInput = gitTokenInput,
@@ -685,6 +688,8 @@ private fun HomeScreen() {
                     onSetAutoConnect = { deviceId, enabled -> BleGatewayService.setAutoConnect(context, deviceId, enabled) },
                     onConnectDevice = { deviceId -> BleGatewayService.connectDevice(context, deviceId) },
                     onDisconnectDevice = { deviceId -> BleGatewayService.disconnectDevice(context, deviceId) },
+                    onTriggerAdvertise = { deviceId -> BleGatewayService.triggerAdvertise(context, deviceId) },
+                    onStopAdvertise = { deviceId -> BleGatewayService.stopAdvertise(context, deviceId) },
                 )
                 2 -> LogsTabContent(
                     isRunning = isRunning,
@@ -1414,6 +1419,7 @@ private fun SensorsTabContent(
     discoveredAdv: List<DiscoveredAdvInstance>,
     sensorLastValues: List<SensorLastValue>,
     deviceLinkStatuses: List<DeviceLinkStatus>,
+    advertisingDeviceIds: Set<String> = emptySet(),
     gitRepoInput: String,
     gitBranchInput: String,
     gitTokenInput: String,
@@ -1440,6 +1446,8 @@ private fun SensorsTabContent(
     onSetAutoConnect: (String, Boolean) -> Unit,
     onConnectDevice: (String) -> Unit = {},
     onDisconnectDevice: (String) -> Unit = {},
+    onTriggerAdvertise: (String) -> Unit = {},
+    onStopAdvertise: (String) -> Unit = {},
 ) {
     val filteredDevices = remember(loadedConfig, boundDevices, discoveredAdv, deviceSearchText) {
         val devices = loadedConfig?.devices ?: emptyList()
@@ -1687,6 +1695,9 @@ private fun SensorsTabContent(
                     onSetAutoConnect = { enabled -> onSetAutoConnect(device.id, enabled) },
                     onConnectDevice = { onConnectDevice(device.id) },
                     onDisconnectDevice = { onDisconnectDevice(device.id) },
+                    isAdvertising = device.id in advertisingDeviceIds,
+                    onTriggerAdvertise = { onTriggerAdvertise(device.id) },
+                    onStopAdvertise = { onStopAdvertise(device.id) },
                 )
             }
         }
@@ -1754,6 +1765,9 @@ private fun DeviceConfigCard(
     onSetAutoConnect: (Boolean) -> Unit,
     onConnectDevice: () -> Unit = {},
     onDisconnectDevice: () -> Unit = {},
+    isAdvertising: Boolean = false,
+    onTriggerAdvertise: () -> Unit = {},
+    onStopAdvertise: () -> Unit = {},
 ) {
     val deviceSensorKeys = remember(device.id, device.sensors) {
         device.sensors.map { "${device.id}/${it.key}" }
@@ -2194,6 +2208,45 @@ private fun DeviceConfigCard(
                     val isActive = isConnected ||
                             linkStatus?.state == DeviceLinkState.Connecting ||
                             linkStatus?.state == DeviceLinkState.Scanning
+
+                    if (isRunning && device.advertise != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Start,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            if (isAdvertising) {
+                                HassDangerOutlinedButton(
+                                    text = stringResource(R.string.device_advertise_stop_btn),
+                                    onClick = onStopAdvertise,
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                OutlinedButton(
+                                    onClick = {},
+                                    enabled = false,
+                                    border = BorderStroke(1.dp, Color.Gray),
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(14.dp),
+                                        strokeWidth = 2.dp,
+                                        color = Color.Gray,
+                                    )
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                    Text(
+                                        text = stringResource(R.string.device_advertising_btn),
+                                        fontSize = 13.sp,
+                                        color = Color.Gray,
+                                    )
+                                }
+                            } else {
+                                HassAccentButton(
+                                    text = stringResource(R.string.device_advertise_btn),
+                                    onClick = onTriggerAdvertise,
+                                )
+                            }
+                        }
+                    }
 
                     if (isRunning && (device.source == Source.gatt_notify || device.source == Source.obd)) {
                         val hasMac = if (device.source == Source.gatt_notify) !device.gatt?.mac.isNullOrBlank() else !device.obd?.mac.isNullOrBlank()

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -328,6 +328,11 @@
     <string name="device_connect_btn">연결</string>
     <string name="device_connecting_btn">연결 중…</string>
     <string name="device_disconnect_btn">연결 해제</string>
+    <string name="device_advertise_btn">요청</string>
+    <string name="device_advertise_stop_btn">중단</string>
+    <string name="device_advertising_btn">송신 중…</string>
+    <string name="log_advertise_no_permission">BLE 광고 실패: BLUETOOTH_ADVERTISE 권한이 허용되지 않았습니다</string>
+    <string name="log_advertise_unsupported">이 기기에서 BLE 광고 송신을 지원하지 않습니다</string>
     <string name="github_error_401">인증 실패: GitHub 토큰이 올바르지 않거나 권한이 없습니다 (401).</string>
     <string name="github_error_404">찾을 수 없음: 저장소나 브랜치를 찾을 수 없습니다. 경로를 확인하세요 (404).</string>
     <string name="github_error_generic">GitHub API 오류: HTTP %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,11 @@
     <string name="device_connect_btn">Connect</string>
     <string name="device_connecting_btn">Connecting…</string>
     <string name="device_disconnect_btn">Disconnect</string>
+    <string name="device_advertise_btn">Request</string>
+    <string name="device_advertise_stop_btn">Stop</string>
+    <string name="device_advertising_btn">Advertising…</string>
+    <string name="log_advertise_no_permission">BLE advertise failed: BLUETOOTH_ADVERTISE permission not granted</string>
+    <string name="log_advertise_unsupported">BLE advertise not supported on this device</string>
     <string name="github_error_401">Unauthorized: GitHub Token is invalid or missing permission.</string>
     <string name="github_error_404">Not Found: Repository or branch not found. Check repository path.</string>
     <string name="github_error_generic">GitHub API Error: HTTP %1$d</string>

--- a/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
@@ -1,0 +1,85 @@
+package dev.eigger.hassble.ble
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AdvertisePayloadTest {
+
+    @Test
+    fun testNextCounter() {
+        assertEquals(1, AdvertisePayload.nextCounter(0))
+        assertEquals(255, AdvertisePayload.nextCounter(254))
+        assertEquals(0, AdvertisePayload.nextCounter(255))
+        assertEquals(1, AdvertisePayload.nextCounter(256))
+    }
+
+    @Test
+    fun testRenderTokenDecimal() {
+        val template = "05CB34{counter}"
+        assertEquals("05CB340", AdvertisePayload.render(template, 0))
+        assertEquals("05CB3442", AdvertisePayload.render(template, 42))
+        assertEquals("05CB34255", AdvertisePayload.render(template, 255))
+    }
+
+    @Test
+    fun testRenderTokenHexFormat() {
+        val template = "05CB3440{counter:02X}"
+        assertEquals("05CB344000", AdvertisePayload.render(template, 0))
+        assertEquals("05CB34400A", AdvertisePayload.render(template, 10))
+        assertEquals("05CB3440FF", AdvertisePayload.render(template, 255))
+    }
+
+    @Test
+    fun testRenderWithoutToken() {
+        val template = "05CB3440FF"
+        assertEquals("05CB3440FF", AdvertisePayload.render(template, 0))
+        assertEquals("05CB3440FF", AdvertisePayload.render(template, 255))
+    }
+
+    @Test
+    fun testToBytesValid() {
+        val bytes = AdvertisePayload.toBytes("05CB344000")
+        assertNotNull(bytes)
+        assertArrayEquals(byteArrayOf(0x05, 0xCB.toByte(), 0x34, 0x40, 0x00), bytes)
+    }
+
+    @Test
+    fun testToBytesInvalid() {
+        // Odd length
+        assertNull(AdvertisePayload.toBytes("05CB3"))
+        // Non-hex chars
+        assertNull(AdvertisePayload.toBytes("05CB3440ZZ"))
+    }
+
+    @Test
+    fun testValidationErrorValid() {
+        assertNull(AdvertisePayload.validationError("05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}"))
+        assertNull(AdvertisePayload.validationError("05CB3440"))
+    }
+
+    @Test
+    fun testValidationErrorBlank() {
+        assertNotNull(AdvertisePayload.validationError(""))
+        assertNotNull(AdvertisePayload.validationError("   "))
+    }
+
+    @Test
+    fun testValidationErrorExceedsMaxPayload() {
+        // 25 bytes (50 hex chars) exceeds 24 bytes limit
+        val tooLong = "00".repeat(25)
+        assertNotNull(AdvertisePayload.validationError(tooLong))
+        // 24 bytes (48 hex chars) is OK
+        val exact24 = "00".repeat(24)
+        assertNull(AdvertisePayload.validationError(exact24))
+    }
+
+    @Test
+    fun testValidationErrorDecimalTokenOddLength() {
+        // "05{counter}" when counter=0 gives "050" (odd length -> invalid hex)
+        val invalidDecimal = "05{counter}"
+        assertNotNull(AdvertisePayload.validationError(invalidDecimal))
+    }
+}

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -1,0 +1,164 @@
+package dev.eigger.hassble.config
+
+import com.charleskorn.kaml.Yaml
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdvertiseConfigTest {
+
+    @Test
+    fun testParseAdvertiseYaml() {
+        val yaml = """
+        devices:
+          - id: mytown_parking
+            name: "마이타운 주차위치"
+            source: advertisement
+            instance_mode: shared
+            match:
+              manufacturer_id: 861
+              manufacturer_hex_prefix: "06CB34447B91F8C69BBE41157C70BB631C"
+              manufacturer_min_length: 20
+            advertise:
+              manufacturer_id: 861
+              payload: "05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}"
+              mode: balanced
+              tx_power: high
+              timeout: 15s
+              repeat_interval: 1s
+              stop_on_response: true
+              connectable: false
+              scannable: true
+            controls:
+              - key: request_location
+                type: button
+                name: "주차위치 요청"
+                action: advertise
+                icon: mdi:car-search
+            sensors:
+              - key: floor
+                icon: mdi:layers-outline
+                source_field: manufacturer_data
+                min_length: 18
+                decode: { offset: 17, length: 1, type: int8 }
+              - key: location
+                platform: text_sensor
+                icon: mdi:map-marker-outline
+                source_field: manufacturer_data
+                min_length: 19
+                decode: { offset: 18, length: 0, type: string }
+        """.trimIndent()
+
+        val config = Yaml.default.decodeFromString(GatewayConfig.serializer(), yaml)
+        assertEquals(1, config.devices.size)
+        val d = config.devices[0]
+        assertEquals("mytown_parking", d.id)
+        assertEquals(Source.advertisement, d.source)
+        assertEquals(AdvertisementInstanceMode.shared, d.instanceMode)
+
+        val adv = d.advertise
+        assertNotNull(adv)
+        assertEquals(861, adv!!.manufacturerId)
+        assertEquals("05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}", adv.payload)
+        assertEquals(AdvertiseModeOption.balanced, adv.mode)
+        assertEquals(AdvertiseTxPowerOption.high, adv.txPower)
+        assertEquals("15s", adv.timeout)
+        assertEquals("1s", adv.repeatInterval)
+        assertTrue(adv.stopOnResponse)
+        assertFalse(adv.connectable)
+        assertTrue(adv.scannable)
+        assertFalse(adv.includeDeviceName)
+
+        val ctrl = d.controls[0]
+        assertEquals("request_location", ctrl.key)
+        assertEquals(ControlType.button, ctrl.type)
+        assertEquals(ControlAction.advertise, ctrl.action)
+
+        val issues = ConfigValidator.validate(config)
+        assertTrue("Expected no ERROR issues, but got: $issues", issues.none { it.level == ValidationLevel.ERROR })
+    }
+
+    @Test
+    fun testRule1_ControlActionWithoutAdvertiseBlock() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            controls = listOf(
+                ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)
+            )
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("requires an 'advertise' block") }
+        assertNotNull(err)
+    }
+
+    @Test
+    fun testRule2_AdvertiseOnNonAdvertisementSource() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.gatt_notify,
+            gatt = GattConfig(serviceUuid = "FFF0", notifyCharUuid = "FFF1", writeCharUuid = "FFF2"),
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB"),
+            controls = listOf(
+                ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)
+            )
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("only supported for source: advertisement") }
+        assertNotNull(err)
+    }
+
+    @Test
+    fun testRule3_AdvertisePayloadInvalid() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "INVALID_HEX_ZZ"),
+            controls = listOf(
+                ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)
+            )
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR }
+        assertNotNull(err)
+    }
+
+    @Test
+    fun testRule4_AdvertiseInstanceModeMacWarning() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.mac,
+            match = MatchConfig(manufacturerId = 861),
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB34"),
+            controls = listOf(
+                ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)
+            )
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("instance_mode: mac") }
+        assertNotNull(warn)
+    }
+
+    @Test
+    fun testRule5_AdvertiseWithoutAdvertiseActionControlWarning() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB34"),
+            controls = emptyList()
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("no control with action: advertise") }
+        assertNotNull(warn)
+    }
+}

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -197,4 +197,27 @@ class AdvertiseConfigTest {
         assertTrue(ConfigValidator.hasDeviceError(issues, "test"))
         assertFalse(ConfigValidator.hasDeviceError(issues, "other_device"))
     }
+
+    @Test
+    fun testCounterStartOutOfRange() {
+        val deviceNegative = DeviceConfig(
+            id = "test_neg",
+            name = "Test",
+            source = Source.advertisement,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB34", counterStart = -1),
+        )
+        val issuesNeg = ConfigValidator.validate(GatewayConfig(devices = listOf(deviceNegative)))
+        val errNeg = issuesNeg.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("counter_start must be between 0 and 255") }
+        assertNotNull(errNeg)
+
+        val deviceTooLarge = DeviceConfig(
+            id = "test_large",
+            name = "Test",
+            source = Source.advertisement,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB34", counterStart = 256),
+        )
+        val issuesLarge = ConfigValidator.validate(GatewayConfig(devices = listOf(deviceTooLarge)))
+        val errLarge = issuesLarge.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("counter_start must be between 0 and 255") }
+        assertNotNull(errLarge)
+    }
 }

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -63,6 +63,8 @@ class AdvertiseConfigTest {
         assertNotNull(adv)
         assertEquals(861, adv!!.manufacturerId)
         assertEquals("05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}", adv.payload)
+        assertEquals(AdvertiseCounterMode.reset, adv.counterMode)
+        assertEquals(0, adv.counterStart)
         assertEquals(AdvertiseModeOption.balanced, adv.mode)
         assertEquals(AdvertiseTxPowerOption.high, adv.txPower)
         assertEquals("15s", adv.timeout)
@@ -79,6 +81,27 @@ class AdvertiseConfigTest {
 
         val issues = ConfigValidator.validate(config)
         assertTrue("Expected no ERROR issues, but got: $issues", issues.none { it.level == ValidationLevel.ERROR })
+    }
+
+    @Test
+    fun testParseAdvertisePersistMode() {
+        val yaml = """
+        devices:
+          - id: mytown_parking
+            name: "마이타운 주차위치"
+            source: advertisement
+            advertise:
+              manufacturer_id: 861
+              payload: "05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}"
+              counter_mode: persist
+              counter_start: 5
+        """.trimIndent()
+
+        val config = Yaml.default.decodeFromString(GatewayConfig.serializer(), yaml)
+        val adv = config.devices[0].advertise
+        assertNotNull(adv)
+        assertEquals(AdvertiseCounterMode.persist, adv!!.counterMode)
+        assertEquals(5, adv.counterStart)
     }
 
     @Test

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -161,4 +161,17 @@ class AdvertiseConfigTest {
         val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("no control with action: advertise") }
         assertNotNull(warn)
     }
+
+    @Test
+    fun testHasDeviceError() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "INVALID_HEX_ZZ"),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        assertTrue(ConfigValidator.hasDeviceError(issues, "test"))
+        assertFalse(ConfigValidator.hasDeviceError(issues, "other_device"))
+    }
 }

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -220,4 +220,19 @@ class AdvertiseConfigTest {
         val errLarge = issuesLarge.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("counter_start must be between 0 and 255") }
         assertNotNull(errLarge)
     }
+
+    @Test
+    fun testIncludeDeviceNameWarning() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(manufacturerId = 861, payload = "05CB34", includeDeviceName = true),
+            controls = listOf(ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("include_device_name: true") }
+        assertNotNull(warn)
+    }
 }

--- a/app/src/test/java/dev/eigger/hassble/decode/DecoderStringTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/decode/DecoderStringTest.kt
@@ -1,0 +1,45 @@
+package dev.eigger.hassble.decode
+
+import dev.eigger.hassble.config.DataType
+import dev.eigger.hassble.config.DecodeConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DecoderStringTest {
+
+    @Test
+    fun testFixedLengthString() {
+        // "B32" -> ASCII 0x42, 0x33, 0x32
+        val bytes = byteArrayOf(0x00, 0x01, 0x42, 0x33, 0x32, 0x99.toByte())
+        val config = DecodeConfig(offset = 2, length = 3, type = DataType.string)
+        val result = Decoder.decodeStructured(bytes, config)
+        assertEquals("B32", result)
+    }
+
+    @Test
+    fun testVariableLengthStringLengthZero() {
+        // length: 0 means read until end of bytes
+        val bytes = byteArrayOf(0x00, 0x01, 0x42, 0x33, 0x32)
+        val config = DecodeConfig(offset = 2, length = 0, type = DataType.string)
+        val result = Decoder.decodeStructured(bytes, config)
+        assertEquals("B32", result)
+    }
+
+    @Test
+    fun testVariableLengthStringWithTrailingPadding() {
+        // "B2  \0" -> should be trimmed to "B2"
+        val bytes = byteArrayOf(0x42, 0x32, 0x20, 0x20, 0x00)
+        val config = DecodeConfig(offset = 0, length = 0, type = DataType.string)
+        val result = Decoder.decodeStructured(bytes, config)
+        assertEquals("B2", result)
+    }
+
+    @Test
+    fun testOffsetOutOfBounds() {
+        val bytes = byteArrayOf(0x42, 0x33)
+        val config = DecodeConfig(offset = 5, length = 0, type = DataType.string)
+        val result = Decoder.decodeStructured(bytes, config)
+        assertNull(result)
+    }
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,3 +61,43 @@ devices:
           offset: 23
           length: 1
           type: uint8
+
+  # 지하주차장 위치 요청 비콘 (BLE 광고 송신 및 수신 예제)
+  # UUID는 본인의 HCI 패킷 캡처에서 추출한 고유값으로 교체하세요.
+  # - id: mytown_parking
+  #   name: "마이타운 주차위치"
+  #   source: advertisement
+  #   instance_mode: shared              # 기둥 MAC이 매번 달라도 엔티티 1벌 유지
+  #   match:
+  #     manufacturer_id: 861             # 0x035D — kaml 파싱을 위해 10진수(decimal) 사용 권장
+  #     manufacturer_hex_prefix: "06<본인_16BYTE_UUID_HEX>"
+  #     manufacturer_min_length: 20
+  #   advertise:
+  #     manufacturer_id: 861
+  #     payload: "05<본인_16BYTE_UUID_HEX>40{counter:02X}"
+  #     mode: balanced                   # low_power | balanced | low_latency
+  #     tx_power: high                   # ultra_low | low | medium | high
+  #     timeout: 15s                     # 이 시간 지나면 자동 송신 중단
+  #     repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가
+  #     stop_on_response: true           # 06 응답 수신 시 즉시 송신 중단
+  #     connectable: false
+  #     scannable: true
+  #   controls:
+  #     - key: request_location
+  #       type: button
+  #       name: "주차위치 요청"
+  #       action: advertise
+  #       icon: mdi:car-search
+  #   sensors:
+  #     - key: floor
+  #       icon: mdi:layers-outline
+  #       source_field: manufacturer_data
+  #       min_length: 18
+  #       decode: { offset: 17, length: 1, type: int8 }
+  #     - key: location
+  #       platform: text_sensor
+  #       icon: mdi:map-marker-outline
+  #       source_field: manufacturer_data
+  #       min_length: 19
+  #       decode: { offset: 18, length: 0, type: string }
+

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,6 +75,8 @@ devices:
   #   advertise:
   #     manufacturer_id: 861
   #     payload: "05<본인_16BYTE_UUID_HEX>40{counter:02X}"
+  #     counter_mode: reset              # reset(기본) | persist
+  #     counter_start: 0                 # reset 모드 시작값 (기본 0)
   #     mode: balanced                   # low_power | balanced | low_latency
   #     tx_power: high                   # ultra_low | low | medium | high
   #     timeout: 15s                     # 이 시간 지나면 자동 송신 중단

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -114,7 +114,7 @@ devices: [ ... ]                    # 아래 참조
 | `manufacturer_id` | ✅ | | BLE Company Identifier (10진수). 예: 861 (=0x035D) |
 | `payload` | ✅ | | Manufacturer Data payload hex (Company ID 2바이트 제외). `{counter}` (10진수), `{counter:02X}` (2자리 hex) 토큰 사용 가능. Legacy 광고 제한으로 최대 24바이트 |
 | `counter_mode` | | `reset` | 카운터 동작 방식: `reset` (버튼 누를 때마다 `counter_start`부터 시작, 버스트 내에서만 증가, DataStore 미사용) \| `persist` (앱 재시작 후에도 DataStore에 누적 저장되어 이어짐) |
-| `counter_start` | | `0` | 카운터 시작값 (0~255). `reset` 모드 시 매 요청 시작값 |
+| `counter_start` | | `0` | 카운터 시작값 (0~255). `reset` 모드 시 매 요청 시작값, `persist` 모드 시 최초 영속 전 초기 시드값 |
 | `mode` | | `balanced` | 광고 주기: `low_power` (~1s) \| `balanced` (~250ms) \| `low_latency` (~100ms) |
 | `tx_power` | | `high` | 송신 출력: `ultra_low` \| `low` \| `medium` \| `high` |
 | `timeout` | | `15s` | 광고 송신 최대 지속 시간 (지나면 자동 중단) |

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -41,8 +41,9 @@ devices: [ ... ]                    # 아래 참조
 | `name` | ✅ | HA 표시 이름 |
 | `source` | ✅ | `advertisement` \| `gatt_notify` \| `obd` |
 | `instance_mode` | | advertisement 전용. `mac`(기본)=MAC별 엔티티, `shared`=프로필 ID 하나로 덮어쓰기 |
+| `advertise` | | advertisement 전용. 앱에서 BLE 광고(TX)를 송신하기 위한 설정 |
 | `sensors` | △ | 센서 목록 (읽기) |
-| `controls` | | 제어 목록 (HA→BLE, gatt_notify/obd) |
+| `controls` | | 제어 목록 (HA→BLE 또는 앱 동작 제어) |
 
 예시: [config.example.yaml](../config.example.yaml)
 ## source: advertisement
@@ -75,6 +76,52 @@ devices: [ ... ]                    # 아래 참조
 | `mac` (기본) | `match.mac` 없으면 스캔된 MAC마다 `{id}_{MAC}` 엔티티 생성. `match.mac` 있으면 단일 기기로 `{id}` 사용 |
 | `shared` | 항상 `{id}` 하나. 여러 기기가 같은 프로필에 매칭되면 **마지막 광고 값**으로 덮어씀. 게이트웨이 시작 시 엔티티 선언 |
 
+### 광고 송신 (advertise)
+
+지하주차장 주차위치 비콘 요청 등 앱에서 BLE Manufacturer Data 광고를 송신(TX)해야 하는 경우 사용합니다.
+
+```yaml
+- id: mytown_parking
+  name: "마이타운 주차위치"
+  source: advertisement
+  instance_mode: shared              # 기둥 MAC이 매번 달라도 엔티티 1벌 유지
+  match:
+    manufacturer_id: 861             # 0x035D — kaml 파싱을 위해 10진수(decimal) 사용 권장
+    manufacturer_hex_prefix: "06CB34..."
+    manufacturer_min_length: 20
+  advertise:
+    manufacturer_id: 861
+    payload: "05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}"
+    mode: balanced                   # low_power | balanced | low_latency
+    tx_power: high                   # ultra_low | low | medium | high
+    timeout: 15s                     # 이 시간 지나면 자동 송신 중단
+    repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가
+    stop_on_response: true           # 이 프로필 광고(match)를 수신하면 즉시 송신 중단
+    connectable: false
+    scannable: true
+  controls:
+    - key: request_location
+      type: button
+      name: "주차위치 요청"
+      action: advertise              # command 대신 앱 내부 광고 송신 동작 실행
+      icon: mdi:car-search
+```
+
+| 필드 | 필수 | 기본값 | 설명 |
+|------|------|--------|------|
+| `manufacturer_id` | ✅ | | BLE Company Identifier (10진수). 예: 861 (=0x035D) |
+| `payload` | ✅ | | Manufacturer Data payload hex (Company ID 2바이트 제외). `{counter}` (10진수), `{counter:02X}` (2자리 hex) 토큰 사용 가능. Legacy 광고 제한으로 최대 24바이트 |
+| `mode` | | `balanced` | 광고 주기: `low_power` (~1s) \| `balanced` (~250ms) \| `low_latency` (~100ms) |
+| `tx_power` | | `high` | 송신 출력: `ultra_low` \| `low` \| `medium` \| `high` |
+| `timeout` | | `15s` | 광고 송신 최대 지속 시간 (지나면 자동 중단) |
+| `repeat_interval` | | `null` | 지정 시 해당 주기마다 counter를 증가시키며 payload 갱신 (생략 시 1회 세팅 후 대기) |
+| `stop_on_response` | | `true` | 이 프로필의 `match` 조건을 만족하는 광고 패킷 수신 시 즉시 광고 송신 중단 |
+| `connectable` | | `false` | BLE 연결 가능 여부 |
+| `scannable` | | `true` | Scannable 광고 여부 |
+| `include_device_name` | | `false` | 광고 패킷에 기기 이름 포함 여부 (31바이트 예산 절약을 위해 기본 false) |
+
+> **알림:** `advertise` 블록이 설정된 기기는 HA에 `{id}_advertising` 진단 바이너리 센서(`binary_sensor`)가 자동으로 생성되어 현재 광고 송신 진행 여부를 보고합니다.
+
 ## source: gatt_notify
 
 ```yaml
@@ -93,8 +140,12 @@ devices: [ ... ]                    # 아래 참조
   controls:
     - key: relay
       type: switch              # switch | number | select | button
-      command: { on: "A10100", off: "A10000" }   # write_char로 전송할 hex
+      command: { on: "A10100", off: "A10000" }   # write_char로 전송할 hex (또는 action 필드 사용)
 ```
+
+컨트롤 필드 `action`:
+- `advertise`: HA button press/switch turn_on 시 `advertise` 블록의 광고 송신을 시작합니다.
+- `stop_advertise`: 광고 송신을 중단합니다.
 
 ## source: obd (ELM327)
 
@@ -149,7 +200,7 @@ ESPHome `ble_elm327`과 동일한 개념. `preset`만 적으면 mode/pid/formula
 | 필드 | 설명 |
 |------|------|
 | `offset` | 시작 바이트 |
-| `length` | 길이 |
+| `length` | 길이 (`string` 타입에서 `0` 또는 생략 시 payload 끝까지) |
 | `type` | int8/uint8/int16/uint16/int32/uint32/float32/**timestamp**/**string** |
 | `endian` | big / little (기본 big) |
 | `bitmask` | 비트 추출 (선택) |
@@ -165,7 +216,7 @@ ESPHome `ble_elm327`과 동일한 개념. `preset`만 적으면 mode/pid/formula
 
 `timestamp` 타입: `offset`부터 4바이트를 **월·일·시·분**(uint8)으로 읽어 ISO 8601 문자열 반환 (예: `2026-06-22T14:30:00`). 연도는 디코딩 시점의 현재 연도. `device_class: timestamp`와 함께 사용.
 
-`string` 타입: `offset`부터 `length`바이트를 ASCII 문자로 연결. `platform: text_sensor`와 함께 사용 (예: 주차 위치 코드 2자).
+`string` 타입: `offset`부터 `length`바이트를 ASCII 문자로 연결 (`length: 0`이면 끝까지 읽음). 뒤쪽 공백 및 null 패딩은 자동으로 제거됩니다. `platform: text_sensor`와 함께 사용 (예: 주차 위치 코드 "B32").
 
 ## publish 억제 (통신 완화, 값 기반 — 앱)
 

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -92,6 +92,8 @@ devices: [ ... ]                    # 아래 참조
   advertise:
     manufacturer_id: 861
     payload: "05CB34447B91F8C69BBE41157C70BB631C40{counter:02X}"
+    counter_mode: reset              # reset(기본) | persist
+    counter_start: 0                 # reset 모드일 때 매 요청 시작값 (기본 0)
     mode: balanced                   # low_power | balanced | low_latency
     tx_power: high                   # ultra_low | low | medium | high
     timeout: 15s                     # 이 시간 지나면 자동 송신 중단
@@ -111,6 +113,8 @@ devices: [ ... ]                    # 아래 참조
 |------|------|--------|------|
 | `manufacturer_id` | ✅ | | BLE Company Identifier (10진수). 예: 861 (=0x035D) |
 | `payload` | ✅ | | Manufacturer Data payload hex (Company ID 2바이트 제외). `{counter}` (10진수), `{counter:02X}` (2자리 hex) 토큰 사용 가능. Legacy 광고 제한으로 최대 24바이트 |
+| `counter_mode` | | `reset` | 카운터 동작 방식: `reset` (버튼 누를 때마다 `counter_start`부터 시작, 버스트 내에서만 증가, DataStore 미사용) \| `persist` (앱 재시작 후에도 DataStore에 누적 저장되어 이어짐) |
+| `counter_start` | | `0` | 카운터 시작값 (0~255). `reset` 모드 시 매 요청 시작값 |
 | `mode` | | `balanced` | 광고 주기: `low_power` (~1s) \| `balanced` (~250ms) \| `low_latency` (~100ms) |
 | `tx_power` | | `high` | 송신 출력: `ultra_low` \| `low` \| `medium` \| `high` |
 | `timeout` | | `15s` | 광고 송신 최대 지속 시간 (지나면 자동 중단) |


### PR DESCRIPTION
## 개요
지하주차장 기둥 비콘 주차위치 요청 등, 앱에서 특정 BLE Manufacturer Data 광고를 송신(TX)하고 응답 수신 또는 타임아웃 시 자동 중단하는 기능을 추가합니다.
프로토콜 포맷은 앱에 하드코딩하지 않고 YAML 설정(`config.yaml`)을 통해 완전하게 정의할 수 있는 범용 구조로 구현되었습니다.

## 주요 변경 사항

### 1. 스키마 및 디코더/검증 엔진
- `DeviceConfig.advertise` 및 `ControlConfig.action` 필드 추가 (`AdvertiseConfig`, `ControlAction` 모델 정의)
- `AdvertisePayload`: `{counter}`(10진수), `{counter:02X}`(2자리 hex) 토큰 치환 및 Legacy AD 24바이트 유효성 검사
- `ConfigValidator`: `action != null`에 대한 command 키 검사 면제 및 advertise 관련 신규 규칙 5개 추가
- `Decoder`: `DataType.string` 가변 길이(`length: 0` 또는 생략 시 끝까지 읽기) 및 패딩 trim 지원

### 2. BLE 광고 송신 엔진
- `BleAdvertiser` 인터페이스 및 `AndroidBleAdvertiser` 구현체 (`BluetoothLeAdvertiser.startAdvertisingSet` 기반)
- `timeout` 및 `repeat_interval` 코루틴 스케줄링으로 데이터 자동 갱신 및 중단
- 블루투스 미지원/비활성화/권한 부족 등 예외 로깅(`LiveEventLogger.log(LogType.TX, ...)`)

### 3. 런타임 & 서비스 & 설정 저장소 연동
- `HassSettingsRepository`: `adv_counters` DataStore 영속 저장 및 기기 삭제 시 정리
- `BleRuntime`: `{id}_advertising` 진단 바이너리 센서 선언, HA 명령 라우팅, `stop_on_response` 응답 수신 시 즉시 중단
- `BleGatewayService`: `AndroidBleAdvertiser` 주입, `advertisingDeviceIds` StateFlow 및 인텐트 액션 핸들링

### 4. 권한 및 UI
- `AndroidManifest.xml`: `BLUETOOTH_ADVERTISE` 권한 선언
- `MainActivity`: Android 12+ 런타임 권한 요청 추가 및 기기 카드에 [요청] / [중단] + 진행 인디케이터 렌더링
- 문자열 리소스(`strings.xml`, `values-ko/strings.xml`) 추가

### 5. 문서 및 버전
- `docs/CONFIG_SCHEMA.md` 가이드 문서화
- `config.example.yaml` 주차위치 요청 예제 추가
- `app/build.gradle.kts`: 버전 1.3.0 (versionCode 65) 업데이트

### 6. 단위 테스트
- `AdvertisePayloadTest`, `AdvertiseConfigTest`, `DecoderStringTest` 추가