### PR TITLE
feat(ble): BLE 광고 백그라운드 WakeLock/하드웨어 타임아웃 및 앱 UI 버튼 가시성 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 65
-        versionName = "1.3.0"
+        versionCode = 66
+        versionName = "1.3.1"
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- BLE (Android 12+)
          neverForLocation은 의도적으로 쓰지 않음: 이 앱은 사용자가 임의의 BLE 기기를 등록하는

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -21,7 +21,9 @@ import dev.eigger.hassble.config.parseDurationMs
 import dev.eigger.hassble.service.LiveEventLogger
 import dev.eigger.hassble.service.LogType
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -34,6 +36,8 @@ class AndroidBleAdvertiser(
     private val scope: CoroutineScope,
 ) : BleAdvertiser {
 
+    private val advertiserScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
     private class Session(
         val config: AdvertiseConfig,
         val callback: AdvertisingSetCallback,
@@ -44,6 +48,7 @@ class AndroidBleAdvertiser(
         val onCounter: (Int) -> Unit,
         val onStopped: (AdvertiseStopReason) -> Unit,
         @Volatile var isStarted: Boolean = false,
+        @Volatile var stopRequested: Boolean = false,
     )
 
     private val sessions = ConcurrentHashMap<String, Session>()
@@ -145,9 +150,9 @@ class AndroidBleAdvertiser(
                 status: Int,
             ) {
                 val currentSession = sessionRef ?: return
-                if (sessions[deviceId] !== currentSession) {
+                if (sessions[deviceId] !== currentSession || currentSession.stopRequested) {
                     // Session was cancelled or replaced before start callback arrived.
-                    // Stop newly started hardware advertising set to prevent orphaned transmission.
+                    // Stop newly started hardware advertising set while the callback wrapper mapping is intact.
                     if (status == ADVERTISE_SUCCESS) {
                         val advertiser = getBluetoothAdvertiser()
                         runCatching { advertiser?.stopAdvertisingSet(this) }
@@ -279,11 +284,12 @@ class AndroidBleAdvertiser(
     @SuppressLint("MissingPermission")
     override fun stop(deviceId: String, reason: AdvertiseStopReason) {
         val session = sessions.remove(deviceId) ?: return
+        session.stopRequested = true
         session.job?.cancel()
         session.job = null
 
         val advertiser = getBluetoothAdvertiser()
-        if (advertiser != null) {
+        if (advertiser != null && session.isStarted) {
             runCatching { advertiser.stopAdvertisingSet(session.callback) }
         }
 
@@ -293,7 +299,13 @@ class AndroidBleAdvertiser(
             val wl = session.wakeLock
             session.wakeLock = null
             if (wl != null && wl.isHeld) {
-                runCatching { wl.release() }
+                // Keep wakeLock held briefly on dedicated advertiserScope so background network flush (OkHttp WS) can complete
+                advertiserScope.launch {
+                    delay(500)
+                    if (wl.isHeld) {
+                        runCatching { wl.release() }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -145,6 +145,16 @@ class AndroidBleAdvertiser(
                 status: Int,
             ) {
                 val currentSession = sessionRef ?: return
+                if (sessions[deviceId] !== currentSession) {
+                    // Session was cancelled or replaced before start callback arrived.
+                    // Stop newly started hardware advertising set to prevent orphaned transmission.
+                    if (status == ADVERTISE_SUCCESS) {
+                        val advertiser = getBluetoothAdvertiser()
+                        runCatching { advertiser?.stopAdvertisingSet(this) }
+                    }
+                    return
+                }
+
                 if (status == ADVERTISE_SUCCESS) {
                     currentSession.advertisingSet = advertisingSet
                     currentSession.isStarted = true
@@ -273,7 +283,7 @@ class AndroidBleAdvertiser(
         session.job = null
 
         val advertiser = getBluetoothAdvertiser()
-        if (advertiser != null && (session.advertisingSet != null || session.isStarted)) {
+        if (advertiser != null) {
             runCatching { advertiser.stopAdvertisingSet(session.callback) }
         }
 
@@ -283,13 +293,7 @@ class AndroidBleAdvertiser(
             val wl = session.wakeLock
             session.wakeLock = null
             if (wl != null && wl.isHeld) {
-                // Keep wakeLock held briefly so background network flush (OkHttp WebSocket frame) can complete
-                scope.launch {
-                    delay(500)
-                    if (wl.isHeld) {
-                        runCatching { wl.release() }
-                    }
-                }
+                runCatching { wl.release() }
             }
         }
     }

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -11,6 +11,7 @@ import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.PowerManager
 import androidx.core.content.ContextCompat
 import dev.eigger.hassble.R
 import dev.eigger.hassble.config.AdvertiseConfig
@@ -38,6 +39,7 @@ class AndroidBleAdvertiser(
         val callback: AdvertisingSetCallback,
         var advertisingSet: AdvertisingSet? = null,
         var job: Job? = null,
+        var wakeLock: PowerManager.WakeLock? = null,
         var counter: Int,
         val onCounter: (Int) -> Unit,
         val onStopped: (AdvertiseStopReason) -> Unit,
@@ -168,6 +170,20 @@ class AndroidBleAdvertiser(
                 }
             }
 
+            override fun onAdvertisingEnabled(
+                advertisingSet: AdvertisingSet?,
+                enable: Boolean,
+                status: Int,
+            ) {
+                if (!enable) {
+                    LiveEventLogger.log(
+                        LogType.TX,
+                        "BLE Advertise hardware duration ended: device=$deviceId, status=$status",
+                    )
+                    stop(deviceId, AdvertiseStopReason.Timeout)
+                }
+            }
+
             override fun onAdvertisingSetStopped(advertisingSet: AdvertisingSet?) {
                 LiveEventLogger.log(LogType.TX, "BLE Advertise stopped: device=$deviceId")
             }
@@ -184,8 +200,17 @@ class AndroidBleAdvertiser(
         sessions[deviceId] = session
         session.onCounter(session.counter)
 
+        val timeoutMs = parseDurationMs(config.timeout, 15_000)
+        val pm = context.getSystemService(PowerManager::class.java)
+        val wakeLock = pm?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "hassble:ble_advertise_$deviceId")?.apply {
+            setReferenceCounted(false)
+        }
+        runCatching {
+            wakeLock?.acquire(timeoutMs + 2_000L)
+        }
+        session.wakeLock = wakeLock
+
         session.job = scope.launch {
-            val timeoutMs = parseDurationMs(config.timeout, 15_000)
             val repeatMs = config.repeatInterval?.let { parseDurationMs(it, 0) }?.takeIf { it > 0 }
 
             val completedNormally = withTimeoutOrNull(timeoutMs) {
@@ -217,7 +242,10 @@ class AndroidBleAdvertiser(
         }
 
         try {
-            advertiser.startAdvertisingSet(parameters, initialData, null, null, null, callback)
+            // duration is in units of 10ms (1 to 65535, 0 = unlimited).
+            // Pass hardware duration to ensure the BLE controller stops advertising even if the CPU is sleeping.
+            val durationUnits = ((timeoutMs + 9) / 10).coerceIn(1, 65535).toInt()
+            advertiser.startAdvertisingSet(parameters, initialData, null, null, null, durationUnits, 0, callback)
         } catch (e: Exception) {
             LiveEventLogger.log(
                 LogType.TX,
@@ -237,6 +265,13 @@ class AndroidBleAdvertiser(
         val session = sessions.remove(deviceId) ?: return
         session.job?.cancel()
         session.job = null
+
+        session.wakeLock?.let { wl ->
+            if (wl.isHeld) {
+                runCatching { wl.release() }
+            }
+        }
+        session.wakeLock = null
 
         val advertiser = getBluetoothAdvertiser()
         if (advertiser != null && (session.advertisingSet != null || session.isStarted)) {

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -175,11 +175,16 @@ class AndroidBleAdvertiser(
                 enable: Boolean,
                 status: Int,
             ) {
+                val currentSession = sessionRef ?: return
+                if (sessions[deviceId] !== currentSession) return
                 if (!enable) {
-                    LiveEventLogger.log(
-                        LogType.TX,
-                        "BLE Advertise hardware duration ended: device=$deviceId, status=$status",
-                    )
+                    val isConnectable = config.connectable
+                    val msg = if (isConnectable) {
+                        "BLE Advertise disabled (duration ended or peer connected): device=$deviceId, status=$status"
+                    } else {
+                        "BLE Advertise hardware duration ended: device=$deviceId, status=$status"
+                    }
+                    LiveEventLogger.log(LogType.TX, msg)
                     stop(deviceId, AdvertiseStopReason.Timeout)
                 }
             }
@@ -243,8 +248,9 @@ class AndroidBleAdvertiser(
 
         try {
             // duration is in units of 10ms (1 to 65535, 0 = unlimited).
-            // Pass hardware duration to ensure the BLE controller stops advertising even if the CPU is sleeping.
-            val durationUnits = ((timeoutMs + 9) / 10).coerceIn(1, 65535).toInt()
+            // If timeout exceeds hardware limit (~655.35s), pass 0 (unlimited) and rely on the coroutine timer.
+            val rawUnits = (timeoutMs + 9) / 10
+            val durationUnits = if (rawUnits in 1..65535) rawUnits.toInt() else 0
             advertiser.startAdvertisingSet(parameters, initialData, null, null, null, durationUnits, 0, callback)
         } catch (e: Exception) {
             LiveEventLogger.log(
@@ -266,18 +272,26 @@ class AndroidBleAdvertiser(
         session.job?.cancel()
         session.job = null
 
-        session.wakeLock?.let { wl ->
-            if (wl.isHeld) {
-                runCatching { wl.release() }
-            }
-        }
-        session.wakeLock = null
-
         val advertiser = getBluetoothAdvertiser()
         if (advertiser != null && (session.advertisingSet != null || session.isStarted)) {
             runCatching { advertiser.stopAdvertisingSet(session.callback) }
         }
-        session.onStopped(reason)
+
+        try {
+            session.onStopped(reason)
+        } finally {
+            val wl = session.wakeLock
+            session.wakeLock = null
+            if (wl != null && wl.isHeld) {
+                // Keep wakeLock held briefly so background network flush (OkHttp WebSocket frame) can complete
+                scope.launch {
+                    delay(500)
+                    if (wl.isHeld) {
+                        runCatching { wl.release() }
+                    }
+                }
+            }
+        }
     }
 
     override fun stopAll() {

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -138,6 +138,7 @@ import dev.eigger.hassble.config.ConfigTemplates
 import dev.eigger.hassble.config.ConfigTemplatesLoader
 import dev.eigger.hassble.config.ConfigMerger
 import dev.eigger.hassble.config.ConfigValidator
+import dev.eigger.hassble.config.ControlAction
 import dev.eigger.hassble.config.DeviceConfig
 import dev.eigger.hassble.config.GatewayConfig
 import dev.eigger.hassble.config.HassBleDefaults
@@ -2029,8 +2030,13 @@ private fun DeviceConfigCard(
                                 color = Color.White,
                                 fontSize = 12.sp,
                             )
+                            val hintRes = if (control.action == ControlAction.advertise || control.action == ControlAction.stop_advertise) {
+                                R.string.controls_app_and_ha_hint
+                            } else {
+                                R.string.controls_ha_only_hint
+                            }
                             Text(
-                                text = stringResource(R.string.controls_ha_only_hint, controlTypeLabel(control.type)),
+                                text = stringResource(hintRes, controlTypeLabel(control.type)),
                                 color = Color.Gray,
                                 fontSize = 10.sp,
                                 modifier = Modifier.padding(bottom = 4.dp),
@@ -2209,41 +2215,55 @@ private fun DeviceConfigCard(
                             linkStatus?.state == DeviceLinkState.Connecting ||
                             linkStatus?.state == DeviceLinkState.Scanning
 
-                    if (isRunning && device.advertise != null) {
+                    if (device.advertise != null) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.Start,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            if (isAdvertising) {
-                                HassDangerOutlinedButton(
-                                    text = stringResource(R.string.device_advertise_stop_btn),
-                                    onClick = onStopAdvertise,
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
+                            if (isRunning) {
+                                if (isAdvertising) {
+                                    HassDangerOutlinedButton(
+                                        text = stringResource(R.string.device_advertise_stop_btn),
+                                        onClick = onStopAdvertise,
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    OutlinedButton(
+                                        onClick = {},
+                                        enabled = false,
+                                        border = BorderStroke(1.dp, Color.Gray),
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(14.dp),
+                                            strokeWidth = 2.dp,
+                                            color = Color.Gray,
+                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Text(
+                                            text = stringResource(R.string.device_advertising_btn),
+                                            fontSize = 13.sp,
+                                            color = Color.Gray,
+                                        )
+                                    }
+                                } else {
+                                    HassAccentButton(
+                                        text = stringResource(R.string.device_advertise_btn),
+                                        onClick = onTriggerAdvertise,
+                                    )
+                                }
+                            } else {
                                 OutlinedButton(
                                     onClick = {},
                                     enabled = false,
-                                    border = BorderStroke(1.dp, Color.Gray),
+                                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)),
                                 ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(14.dp),
-                                        strokeWidth = 2.dp,
-                                        color = Color.Gray,
-                                    )
-                                    Spacer(modifier = Modifier.width(6.dp))
                                     Text(
-                                        text = stringResource(R.string.device_advertising_btn),
+                                        text = stringResource(R.string.device_advertise_btn_stopped),
                                         fontSize = 13.sp,
                                         color = Color.Gray,
                                     )
                                 }
-                            } else {
-                                HassAccentButton(
-                                    text = stringResource(R.string.device_advertise_btn),
-                                    onClick = onTriggerAdvertise,
-                                )
                             }
                         }
                     }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -143,6 +143,7 @@
     <string name="bind_locked_running">기기 바인딩을 변경하려면 게이트웨이를 먼저 정지하세요.</string>
     <string name="ha_controls">Home Assistant 제어</string>
     <string name="controls_ha_only_hint">Home Assistant에서 제어 (%1$s)</string>
+    <string name="controls_app_and_ha_hint">앱 및 Home Assistant에서 제어 (%1$s)</string>
     <string name="control_type_switch">스위치</string>
     <string name="control_type_number">숫자</string>
     <string name="control_type_select">선택</string>
@@ -329,6 +330,7 @@
     <string name="device_connecting_btn">연결 중…</string>
     <string name="device_disconnect_btn">연결 해제</string>
     <string name="device_advertise_btn">요청</string>
+    <string name="device_advertise_btn_stopped">요청 (게이트웨이 정지됨)</string>
     <string name="device_advertise_stop_btn">중단</string>
     <string name="device_advertising_btn">송신 중…</string>
     <string name="log_advertise_no_permission">BLE 광고 실패: BLUETOOTH_ADVERTISE 권한이 허용되지 않았습니다</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <!-- Controls -->
     <string name="ha_controls">Home Assistant controls</string>
     <string name="controls_ha_only_hint">Controlled from Home Assistant (%1$s)</string>
+    <string name="controls_app_and_ha_hint">Controlled from App &amp; Home Assistant (%1$s)</string>
     <string name="control_type_switch">switch</string>
     <string name="control_type_number">number</string>
     <string name="control_type_select">select</string>
@@ -336,6 +337,7 @@
     <string name="device_connecting_btn">Connecting…</string>
     <string name="device_disconnect_btn">Disconnect</string>
     <string name="device_advertise_btn">Request</string>
+    <string name="device_advertise_btn_stopped">Request (Gateway stopped)</string>
     <string name="device_advertise_stop_btn">Stop</string>
     <string name="device_advertising_btn">Advertising…</string>
     <string name="log_advertise_no_permission">BLE advertise failed: BLUETOOTH_ADVERTISE permission not granted</string>


### PR DESCRIPTION
## 개요
스마트폰 화면이 꺼진 백그라운드 상태에서 Home Assistant의 요청으로 BLE 광고를 송신할 때 안드로이드 Doze 모드로 인해 15초 타임아웃 및 HA `off` 전송이 지연되는 문제를 해결하고, 앱 UI에서도 버튼의 존재와 동작을 직관적으로 확인할 수 있도록 개선합니다.

## 주요 변경 사항

### 1. 백그라운드 BLE 광고 타이머 및 WakeLock 개선
- **WakeLock (`PARTIAL_WAKE_LOCK`) 획득**: 광고 송신 세션 시작 시 `hassble:ble_advertise_{deviceId}` WakeLock을 획득하고 세션 종료 시 안전하게 해제하여, 화면 꺼짐 상태에서도 코루틴 타이머 카운트다운과 HA WebSocket `off` 상태 전송이 즉시 이루어지도록 보장
- **BLE 하드웨어 칩셋 타임아웃 (`duration`) 지정**: `BluetoothLeAdvertiser.startAdvertisingSet` 호출 시 10ms 단위의 `duration` 파라미터를 전달하여, OS CPU 상태와 무관하게 블루투스 하드웨어 레벨에서 15초 후 자동 종료되도록 이중 안전장치 적용
- **하드웨어 종료 콜백 처리**: `AdvertisingSetCallback.onAdvertisingEnabled(enable=false)` 수신 시 세션을 정리하고 `AdvertiseStopReason.Timeout`을 트리거하도록 구현
- **권한 선언**: `AndroidManifest.xml`에 `android.permission.WAKE_LOCK` 추가

### 2. 앱 UI 버튼 및 컨트롤 힌트 개선
- **기기 카드 하단 버튼 상시 노출**: 게이트웨이가 정지(`STOPPED`) 상태일 때도 `[요청 (게이트웨이 정지됨)]` 비활성화(Disabled) 버튼을 항상 노출하여 앱 내에서 버튼의 존재를 쉽게 인지 가능
- **상세 컨트롤 힌트 수정**: `action: advertise` 컨트롤의 설명 문구를 `"Home Assistant에서 제어"`에서 `"앱 및 Home Assistant에서 제어"`로 변경
- **문자열 리소스 추가**: `device_advertise_btn_stopped`, `controls_app_and_ha_hint` 추가 (한국어/영어)

### 3. 버전 업데이트
- `versionCode = 66`, `versionName = "1.3.1"`