### PR TITLE
feat(ble): advertise payload_phases for parking request bursts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 66
-        versionName = "1.3.1"
+        versionCode = 67
+        versionName = "1.4.0"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AcquisitionSources.kt
@@ -105,7 +105,7 @@ interface Elm327Source {
 interface BleAdvertiser {
     /**
      * [counterSeed]부터 시작해 광고를 켠다. 이미 켜져 있으면 재시작한다.
-     * timeout / repeat_interval 스케줄링은 구현체가 담당한다.
+     * timeout / repeat_interval / payload_phases 스케줄링은 구현체가 담당한다.
      * [onCounter]는 counter가 바뀔 때마다(영속 저장용), [onStopped]는 어떤 이유로든
      * 송신이 끝났을 때 호출된다.
      */

--- a/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
@@ -1,27 +1,44 @@
 package dev.eigger.hassble.ble
 
+import dev.eigger.hassble.config.AdvertisePayloadPhase
+
 object AdvertisePayload {
     /** legacy 광고 31바이트 - flags AD(3) - AD 헤더(2) - company ID(2) = 24바이트 */
     const val MAX_MANUFACTURER_PAYLOAD = 24
 
-    private val TOKEN_REGEX = Regex("""\{counter(?::([^}]+))?\}""")
+    private val TOKEN_REGEX = Regex("""\{(counter|state)(?::([^}]+))?\}""")
 
-    /** counter는 1바이트 순환 (0~255). */
+    /** counter는 1바이트 순환 (0~255). 0xFF 다음은 0. */
     fun nextCounter(current: Int): Int = (current + 1) and 0xFF
 
+    fun hasStateToken(template: String): Boolean = TOKEN_REGEX.containsMatchIn(template) &&
+        TOKEN_REGEX.findAll(template).any { it.groupValues[1] == "state" }
+
+    fun phaseTemplate(basePayload: String, phase: AdvertisePayloadPhase?): String {
+        val override = phase?.payload?.trim().orEmpty()
+        return override.ifEmpty { basePayload }
+    }
+
+    fun phaseState(phase: AdvertisePayloadPhase?): Int = (phase?.state ?: 0) and 0xFF
+
     /**
-     * {counter} → 10진수, {counter:02X} → String.format 적용.
+     * {counter} / {state} → 10진수, {counter:02X} / {state:02X} → String.format 적용.
      * 토큰이 없으면 원문 그대로 반환한다.
      */
-    fun render(template: String, counter: Int): String {
+    fun render(template: String, counter: Int, state: Int = 0): String {
         return TOKEN_REGEX.replace(template) { m ->
-            val fmt = m.groupValues[1]
+            val value = if (m.groupValues[1] == "state") state else counter
+            val fmt = m.groupValues[2]
             if (fmt.isEmpty()) {
-                counter.toString()
+                value.toString()
             } else {
-                runCatching { String.format("%$fmt", counter) }.getOrElse { counter.toString() }
+                runCatching { String.format("%$fmt", value) }.getOrElse { value.toString() }
             }
         }
+    }
+
+    fun renderPhase(basePayload: String, counter: Int, phase: AdvertisePayloadPhase?): String {
+        return render(phaseTemplate(basePayload, phase), counter, phaseState(phase))
     }
 
     /** 렌더된 hex를 바이트로. 홀수 길이·비 hex 문자면 null. */
@@ -39,25 +56,23 @@ object AdvertisePayload {
     }
 
     /** 설정 검증용. 성공하면 null, 실패하면 사람이 읽을 수 있는 사유. */
-    fun validationError(template: String): String? {
+    fun validationError(template: String, counters: List<Int> = listOf(0, 255), states: List<Int> = listOf(0, 255)): String? {
         if (template.isBlank()) return "payload cannot be blank"
-        val testCounters = listOf(0, 255)
-        for (c in testCounters) {
-            val rendered = try {
-                TOKEN_REGEX.replace(template) { m ->
-                    val fmt = m.groupValues[1]
-                    if (fmt.isEmpty()) c.toString() else String.format("%$fmt", c)
+        for (c in counters) {
+            for (s in states) {
+                val rendered = try {
+                    render(template, c, s)
+                } catch (e: Exception) {
+                    return "invalid token format in payload: ${e.message}"
                 }
-            } catch (e: Exception) {
-                return "invalid token format in payload: ${e.message}"
-            }
-            val bytes = toBytes(rendered)
-                ?: return "payload '$rendered' is not a valid hex string"
-            if (bytes.isEmpty()) {
-                return "payload cannot be empty"
-            }
-            if (bytes.size > MAX_MANUFACTURER_PAYLOAD) {
-                return "payload size (${bytes.size} bytes) exceeds maximum legacy advertisement limit ($MAX_MANUFACTURER_PAYLOAD bytes)"
+                val bytes = toBytes(rendered)
+                    ?: return "payload '$rendered' is not a valid hex string"
+                if (bytes.isEmpty()) {
+                    return "payload cannot be empty"
+                }
+                if (bytes.size > MAX_MANUFACTURER_PAYLOAD) {
+                    return "payload size (${bytes.size} bytes) exceeds maximum legacy advertisement limit ($MAX_MANUFACTURER_PAYLOAD bytes)"
+                }
             }
         }
         return null

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -243,6 +243,12 @@ class AndroidBleAdvertiser(
             val completedNormally = withTimeoutOrNull(timeoutMs) {
                 when {
                     phases.isNotEmpty() -> {
+                        while (sessions[deviceId] === session && isActive && !session.isStarted) {
+                            delay(20)
+                        }
+                        if (sessions[deviceId] !== session || !session.isStarted) {
+                            return@withTimeoutOrNull true
+                        }
                         for ((index, phase) in phases.withIndex()) {
                             if (sessions[deviceId] !== session) return@withTimeoutOrNull true
                             if (index > 0) {
@@ -332,6 +338,14 @@ class AndroidBleAdvertiser(
 
     private fun updateAdvertisingData(session: Session, deviceId: String, phase: AdvertisePayloadPhase?) {
         val updatedData = buildAdvertiseData(session.config, session.counter, phase) ?: return
+        val advertisingSet = session.advertisingSet
+        if (advertisingSet == null) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise update skipped: device=$deviceId, advertising set not ready",
+            )
+            return
+        }
         val hex = AdvertisePayload.renderPhase(session.config.payload, session.counter, phase)
         val stateNote = phase?.state?.let { ", state=$it" } ?: ""
         LiveEventLogger.log(
@@ -339,7 +353,7 @@ class AndroidBleAdvertiser(
             "BLE Advertise updated: device=$deviceId, counter=${session.counter}$stateNote, hex=$hex",
         )
         runCatching {
-            session.advertisingSet?.setAdvertisingData(updatedData)
+            advertisingSet.setAdvertisingData(updatedData)
         }
     }
 

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -16,6 +16,7 @@ import androidx.core.content.ContextCompat
 import dev.eigger.hassble.R
 import dev.eigger.hassble.config.AdvertiseConfig
 import dev.eigger.hassble.config.AdvertiseModeOption
+import dev.eigger.hassble.config.AdvertisePayloadPhase
 import dev.eigger.hassble.config.AdvertiseTxPowerOption
 import dev.eigger.hassble.config.parseDurationMs
 import dev.eigger.hassble.service.LiveEventLogger
@@ -110,7 +111,9 @@ class AndroidBleAdvertiser(
             return false
         }
 
-        val initialData = buildAdvertiseData(config, counterSeed)
+        val phases = config.payloadPhases
+        val initialPhase = phases.firstOrNull()
+        val initialData = buildAdvertiseData(config, counterSeed, initialPhase)
         if (initialData == null) {
             LiveEventLogger.log(
                 LogType.TX,
@@ -163,7 +166,7 @@ class AndroidBleAdvertiser(
                 if (status == ADVERTISE_SUCCESS) {
                     currentSession.advertisingSet = advertisingSet
                     currentSession.isStarted = true
-                    val hex = AdvertisePayload.render(config.payload, currentSession.counter)
+                    val hex = AdvertisePayload.renderPhase(config.payload, currentSession.counter, initialPhase)
                     LiveEventLogger.log(
                         LogType.TX,
                         "BLE Advertise started: device=$deviceId, txPower=$txPower, hex=$hex",
@@ -231,32 +234,38 @@ class AndroidBleAdvertiser(
         session.wakeLock = wakeLock
 
         session.job = scope.launch {
-            val repeatMs = config.repeatInterval?.let { parseDurationMs(it, 0) }?.takeIf { it > 0 }
+            val repeatMs = if (phases.isEmpty()) {
+                config.repeatInterval?.let { parseDurationMs(it, 0) }?.takeIf { it > 0 }
+            } else {
+                null
+            }
 
             val completedNormally = withTimeoutOrNull(timeoutMs) {
-                if (repeatMs != null) {
-                    while (isActive) {
-                        delay(repeatMs)
-                        if (sessions[deviceId] !== session) return@withTimeoutOrNull true
-                        session.counter = AdvertisePayload.nextCounter(session.counter)
-                        session.onCounter(session.counter)
-                        val updatedData = buildAdvertiseData(config, session.counter)
-                        if (updatedData != null) {
-                            val hex = AdvertisePayload.render(config.payload, session.counter)
-                            LiveEventLogger.log(
-                                LogType.TX,
-                                "BLE Advertise updated: device=$deviceId, counter=${session.counter}, hex=$hex",
-                            )
-                            runCatching {
-                                session.advertisingSet?.setAdvertisingData(updatedData)
+                when {
+                    phases.isNotEmpty() -> {
+                        for ((index, phase) in phases.withIndex()) {
+                            if (sessions[deviceId] !== session) return@withTimeoutOrNull true
+                            if (index > 0) {
+                                updateAdvertisingData(session, deviceId, phase)
                             }
+                            val phaseMs = parseDurationMs(phase.duration, 0).takeIf { it > 0 } ?: continue
+                            delay(phaseMs)
                         }
                     }
-                } else {
-                    awaitCancellation()
+                    repeatMs != null -> {
+                        while (isActive) {
+                            delay(repeatMs)
+                            if (sessions[deviceId] !== session) return@withTimeoutOrNull true
+                            session.counter = AdvertisePayload.nextCounter(session.counter)
+                            session.onCounter(session.counter)
+                            updateAdvertisingData(session, deviceId, phase = null)
+                        }
+                    }
+                    else -> awaitCancellation()
                 }
             }
-            if (completedNormally == null) {
+            if (sessions[deviceId] !== session) return@launch
+            if (completedNormally == null || phases.isNotEmpty()) {
                 stop(deviceId, AdvertiseStopReason.Timeout)
             }
         }
@@ -321,8 +330,25 @@ class AndroidBleAdvertiser(
         return sessions.containsKey(deviceId)
     }
 
-    private fun buildAdvertiseData(config: AdvertiseConfig, counter: Int): AdvertiseData? {
-        val renderedHex = AdvertisePayload.render(config.payload, counter)
+    private fun updateAdvertisingData(session: Session, deviceId: String, phase: AdvertisePayloadPhase?) {
+        val updatedData = buildAdvertiseData(session.config, session.counter, phase) ?: return
+        val hex = AdvertisePayload.renderPhase(session.config.payload, session.counter, phase)
+        val stateNote = phase?.state?.let { ", state=$it" } ?: ""
+        LiveEventLogger.log(
+            LogType.TX,
+            "BLE Advertise updated: device=$deviceId, counter=${session.counter}$stateNote, hex=$hex",
+        )
+        runCatching {
+            session.advertisingSet?.setAdvertisingData(updatedData)
+        }
+    }
+
+    private fun buildAdvertiseData(
+        config: AdvertiseConfig,
+        counter: Int,
+        phase: AdvertisePayloadPhase? = null,
+    ): AdvertiseData? {
+        val renderedHex = AdvertisePayload.renderPhase(config.payload, counter, phase)
         val bytes = AdvertisePayload.toBytes(renderedHex) ?: return null
         return AdvertiseData.Builder()
             .addManufacturerData(config.manufacturerId, bytes)

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -336,6 +336,7 @@ class AndroidBleAdvertiser(
         return sessions.containsKey(deviceId)
     }
 
+    @SuppressLint("MissingPermission")
     private fun updateAdvertisingData(session: Session, deviceId: String, phase: AdvertisePayloadPhase?) {
         val updatedData = buildAdvertiseData(session.config, session.counter, phase) ?: return
         val advertisingSet = session.advertisingSet

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -147,7 +147,8 @@ enum class AdvertiseCounterMode { reset, persist }
 
 /**
  * 광고 송신(TX) 설정. advertisement 소스 전용.
- * payload는 manufacturer payload(company ID 제외) hex이며 {counter} / {counter:02X} 토큰을 쓸 수 있다.
+ * payload는 manufacturer payload(company ID 제외) hex이며
+ * {counter} / {counter:02X}, {state} / {state:02X} 토큰을 쓸 수 있다.
  */
 @Serializable
 data class AdvertiseConfig(
@@ -158,13 +159,29 @@ data class AdvertiseConfig(
     val mode: AdvertiseModeOption = AdvertiseModeOption.balanced,
     @SerialName("tx_power") val txPower: AdvertiseTxPowerOption = AdvertiseTxPowerOption.high,
     val timeout: String = "15s",
-    /** 지정하면 이 주기마다 payload를 갱신(=counter 증가). 생략하면 누름당 1회만 세팅. */
+    /** 지정하면 이 주기마다 payload를 갱신(=counter 증가). 생략하면 누름당 1회만 세팅. payload_phases가 있으면 무시. */
     @SerialName("repeat_interval") val repeatInterval: String? = null,
+    /**
+     * 같은 카운터로 payload/{state}만 바꿔 가며 송신. 마지막 단계가 끝나면 중단.
+     * timeout은 전체 최대 시간(페이즈 합보다 짧으면 timeout이 이김).
+     */
+    @SerialName("payload_phases") val payloadPhases: List<AdvertisePayloadPhase> = emptyList(),
     /** 이 device의 match에 걸리는 광고를 수신하면 즉시 송신 중단. */
     @SerialName("stop_on_response") val stopOnResponse: Boolean = true,
     val connectable: Boolean = false,
     val scannable: Boolean = true,
     @SerialName("include_device_name") val includeDeviceName: Boolean = false,
+)
+
+/** advertise.payload_phases 한 단계. 카운터는 올리지 않고 state/payload만 바꾼다. */
+@Serializable
+data class AdvertisePayloadPhase(
+    /** 0~255. payload 템플릿의 {state}/{state:02X}에 들어간다. kaml hex 리터럴은 불안정하므로 10진수 권장(0x41 → 65). */
+    val state: Int? = null,
+    /** 이 단계를 유지할 시간. 끝나면 다음 단계로 넘어가거나 송신을 중단한다. */
+    val duration: String,
+    /** 지정하면 기기 payload 대신 이 hex를 쓴다. {counter}/{state} 토큰 사용 가능. */
+    val payload: String? = null,
 )
 
 enum class AdvertiseModeOption { low_power, balanced, low_latency }

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -185,6 +185,64 @@ object ConfigValidator {
                     devicePath(id, "advertise.include_device_name")
                 )
             }
+            val phases = device.advertise.payloadPhases
+            if (AdvertisePayload.hasStateToken(device.advertise.payload) && phases.isEmpty()) {
+                issues += ValidationIssue(
+                    ValidationLevel.ERROR, id, null,
+                    "payload contains {state} but advertise.payload_phases is empty",
+                    devicePath(id, "advertise.payload")
+                )
+            }
+            if (phases.isNotEmpty() && !device.advertise.repeatInterval.isNullOrBlank()) {
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "repeat_interval is ignored when payload_phases is set — counter stays fixed across phases",
+                    devicePath(id, "advertise.repeat_interval")
+                )
+            }
+            for ((index, phase) in phases.withIndex()) {
+                val phasePath = devicePath(id, "advertise.payload_phases[$index]")
+                if (parseDurationMs(phase.duration, 0) <= 0) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, null,
+                        "payload_phases[$index].duration '${phase.duration}' must be a positive duration",
+                        "$phasePath.duration"
+                    )
+                }
+                if (phase.state != null && phase.state !in 0..255) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, null,
+                        "payload_phases[$index].state must be between 0 and 255 (got ${phase.state})",
+                        "$phasePath.state"
+                    )
+                }
+                val template = AdvertisePayload.phaseTemplate(device.advertise.payload, phase)
+                if (AdvertisePayload.hasStateToken(template) && phase.state == null) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, null,
+                        "payload_phases[$index] has a {state} token but no state value",
+                        "$phasePath.state"
+                    )
+                }
+                if (phase.state != null && !AdvertisePayload.hasStateToken(template)) {
+                    issues += ValidationIssue(
+                        ValidationLevel.WARNING, id, null,
+                        "payload_phases[$index].state is set but payload has no {state} token",
+                        "$phasePath.state"
+                    )
+                }
+                val phasePayloadErr = AdvertisePayload.validationError(
+                    template,
+                    states = listOf(phase.state ?: 0, 255),
+                )
+                if (phasePayloadErr != null) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, null,
+                        "payload_phases[$index]: $phasePayloadErr",
+                        phasePath
+                    )
+                }
+            }
         }
 
         // ── 컨트롤 검증 ────────────────────────────────────────────────────────

--- a/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
@@ -1,9 +1,12 @@
 package dev.eigger.hassble.ble
 
+import dev.eigger.hassble.config.AdvertisePayloadPhase
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AdvertisePayloadTest {
@@ -81,5 +84,33 @@ class AdvertisePayloadTest {
         // "05{counter}" when counter=0 gives "050" (odd length -> invalid hex)
         val invalidDecimal = "05{counter}"
         assertNotNull(AdvertisePayload.validationError(invalidDecimal))
+    }
+
+    @Test
+    fun testRenderStateTokenHexFormat() {
+        val template = "02050064{state:02X}{counter:02X}"
+        assertEquals("020500644100", AdvertisePayload.render(template, 0, 0x41))
+        assertEquals("020500644004", AdvertisePayload.render(template, 4, 0x40))
+        assertEquals("02050064FF0A", AdvertisePayload.render(template, 10, 255))
+    }
+
+    @Test
+    fun testRenderPhaseKeepsCounter() {
+        val base = "02050064{state:02X}{counter:02X}"
+        val press = AdvertisePayloadPhase(state = 0x41, duration = "200ms")
+        val hold = AdvertisePayloadPhase(state = 0x40, duration = "3s")
+        assertEquals("020500644104", AdvertisePayload.renderPhase(base, 4, press))
+        assertEquals("020500644004", AdvertisePayload.renderPhase(base, 4, hold))
+    }
+
+    @Test
+    fun testHasStateToken() {
+        assertTrue(AdvertisePayload.hasStateToken("02050064{state:02X}{counter:02X}"))
+        assertFalse(AdvertisePayload.hasStateToken("0205006441{counter:02X}"))
+    }
+
+    @Test
+    fun testValidationErrorWithStateToken() {
+        assertNull(AdvertisePayload.validationError("02050064{state:02X}{counter:02X}"))
     }
 }

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -235,4 +235,101 @@ class AdvertiseConfigTest {
         val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("include_device_name: true") }
         assertNotNull(warn)
     }
+
+    @Test
+    fun testParsePayloadPhasesYaml() {
+        val yaml = """
+        devices:
+          - id: parking_beacon
+            name: "Parking Beacon"
+            source: advertisement
+            advertise:
+              manufacturer_id: 861
+              payload: "02050064{state:02X}{counter:02X}"
+              counter_mode: persist
+              payload_phases:
+                - state: 65
+                  duration: 200ms
+                - state: 64
+                  duration: 3s
+            controls:
+              - key: request_location
+                type: button
+                action: advertise
+        """.trimIndent()
+
+        val config = Yaml.default.decodeFromString(GatewayConfig.serializer(), yaml)
+        val adv = config.devices[0].advertise
+        assertNotNull(adv)
+        assertEquals(AdvertiseCounterMode.persist, adv!!.counterMode)
+        assertEquals(2, adv.payloadPhases.size)
+        assertEquals(65, adv.payloadPhases[0].state)
+        assertEquals("200ms", adv.payloadPhases[0].duration)
+        assertEquals(64, adv.payloadPhases[1].state)
+        assertEquals("3s", adv.payloadPhases[1].duration)
+
+        val issues = ConfigValidator.validate(config)
+        assertTrue("Expected no ERROR issues, but got: $issues", issues.none { it.level == ValidationLevel.ERROR })
+    }
+
+    @Test
+    fun testStateTokenWithoutPhasesIsError() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(
+                manufacturerId = 861,
+                payload = "02050064{state:02X}{counter:02X}",
+            ),
+            controls = listOf(ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("{state}") }
+        assertNotNull(err)
+    }
+
+    @Test
+    fun testPayloadPhasesIgnoresRepeatInterval() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(
+                manufacturerId = 861,
+                payload = "02050064{state:02X}{counter:02X}",
+                repeatInterval = "1s",
+                payloadPhases = listOf(
+                    AdvertisePayloadPhase(state = 65, duration = "200ms"),
+                    AdvertisePayloadPhase(state = 64, duration = "3s"),
+                ),
+            ),
+            controls = listOf(ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        assertTrue(issues.none { it.level == ValidationLevel.ERROR })
+        val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("repeat_interval is ignored") }
+        assertNotNull(warn)
+    }
+
+    @Test
+    fun testPayloadPhaseInvalidDuration() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(
+                manufacturerId = 861,
+                payload = "02050064{state:02X}{counter:02X}",
+                payloadPhases = listOf(AdvertisePayloadPhase(state = 65, duration = "nope")),
+            ),
+            controls = listOf(ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("duration") }
+        assertNotNull(err)
+    }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,7 +80,7 @@ devices:
   #     mode: balanced                   # low_power | balanced | low_latency
   #     tx_power: high                   # ultra_low | low | medium | high
   #     timeout: 15s                     # 이 시간 지나면 자동 송신 중단
-  #     repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가
+  #     repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가. payload_phases가 있으면 무시
   #     stop_on_response: true           # 06 응답 수신 시 즉시 송신 중단
   #     connectable: false
   #     scannable: true

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -97,7 +97,12 @@ devices: [ ... ]                    # 아래 참조
     mode: balanced                   # low_power | balanced | low_latency
     tx_power: high                   # ultra_low | low | medium | high
     timeout: 15s                     # 이 시간 지나면 자동 송신 중단
-    repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가
+    repeat_interval: 1s              # (선택) 이 주기로 payload 갱신 = counter 증가. payload_phases가 있으면 무시
+    # payload_phases:                # (선택) 같은 카운터로 {state}만 바꿔 가며 송신. 마지막 단계 후 중단
+    #   - state: 65                  # 0x41 — kaml hex 리터럴은 불안정하므로 10진수
+    #     duration: 200ms
+    #   - state: 64                  # 0x40
+    #     duration: 3s
     stop_on_response: true           # 이 프로필 광고(match)를 수신하면 즉시 송신 중단
     connectable: false
     scannable: true
@@ -112,13 +117,14 @@ devices: [ ... ]                    # 아래 참조
 | 필드 | 필수 | 기본값 | 설명 |
 |------|------|--------|------|
 | `manufacturer_id` | ✅ | | BLE Company Identifier (10진수). 예: 861 (=0x035D) |
-| `payload` | ✅ | | Manufacturer Data payload hex (Company ID 2바이트 제외). `{counter}` (10진수), `{counter:02X}` (2자리 hex) 토큰 사용 가능. Legacy 광고 제한으로 최대 24바이트 |
-| `counter_mode` | | `reset` | 카운터 동작 방식: `reset` (버튼 누를 때마다 `counter_start`부터 시작, 버스트 내에서만 증가, DataStore 미사용) \| `persist` (앱 재시작 후에도 DataStore에 누적 저장되어 이어짐) |
+| `payload` | ✅ | | Manufacturer Data payload hex (Company ID 2바이트 제외). `{counter}` / `{counter:02X}`, `{state}` / `{state:02X}` 토큰 사용 가능. Legacy 광고 제한으로 최대 24바이트 |
+| `counter_mode` | | `reset` | 카운터 동작 방식: `reset` (버튼 누를 때마다 `counter_start`부터 시작, DataStore 미사용) \| `persist` (앱 재시작 후에도 DataStore에 누적 저장되어 이어짐). 0xFF 다음은 0 |
 | `counter_start` | | `0` | 카운터 시작값 (0~255). `reset` 모드 시 매 요청 시작값, `persist` 모드 시 최초 영속 전 초기 시드값 |
 | `mode` | | `balanced` | 광고 주기: `low_power` (~1s) \| `balanced` (~250ms) \| `low_latency` (~100ms) |
 | `tx_power` | | `high` | 송신 출력: `ultra_low` \| `low` \| `medium` \| `high` |
-| `timeout` | | `15s` | 광고 송신 최대 지속 시간 (지나면 자동 중단) |
-| `repeat_interval` | | `null` | 지정 시 해당 주기마다 counter를 증가시키며 payload 갱신 (생략 시 1회 세팅 후 대기) |
+| `timeout` | | `15s` | 광고 송신 최대 지속 시간 (지나면 자동 중단). `payload_phases`가 있으면 전체 상한 |
+| `repeat_interval` | | `null` | 지정 시 해당 주기마다 counter를 증가시키며 payload 갱신 (생략 시 1회 세팅 후 대기). `payload_phases`가 있으면 무시 |
+| `payload_phases` | | `[]` | 같은 카운터로 `{state}`/payload만 바꿔 가며 송신. 마지막 단계 duration이 끝나면 중단. 각 항목: `state`(0~255, 10진수), `duration`, 선택 `payload` |
 | `stop_on_response` | | `true` | 이 프로필의 `match` 조건을 만족하는 광고 패킷 수신 시 즉시 광고 송신 중단 |
 | `connectable` | | `false` | BLE 연결 가능 여부 |
 | `scannable` | | `true` | Scannable 광고 여부 |


### PR DESCRIPTION
## Summary
- BLE 광고 송신에 `payload_phases`와 `{state}` 토큰을 추가해, 버튼을 누를 때마다 카운터만 올리고 버스트 중에는 같은 카운터로 `0x41`(press) → `0x40`(hold)만 전환합니다.
- 페이즈 전환은 광고 세트가 실제로 시작된 뒤에만 적용합니다.
- 버전을 1.4.0 (versionCode 67)으로 올렸습니다.

## Test plan
- [ ] unit test: `AdvertisePayloadTest`, `AdvertiseConfigTest`
- [ ] parking_beacon 요청 버튼 1회: 카운터 고정, 약 200ms `...41`, 이후 3초 `...40`
- [ ] 두 번째 요청: 카운터가 +1 되고 0xFF 다음은 0
- [ ] 04 응답 수신 시 송신 즉시 중단 (`stop_on_response`)
- [ ] 기존 `repeat_interval`만 쓰는 광고 프로필(마이타운 등)은 이전과 동일하게 동작
