### PR TITLE
feat(ble): advertise local_name for parking Complete Local Name

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "dev.eigger.hassble"
         minSdk = 26
         targetSdk = 35
-        versionCode = 67
-        versionName = "1.4.0"
+        versionCode = 68
+        versionName = "1.4.1"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/eigger/hassble/HassBleApp.kt
+++ b/app/src/main/java/dev/eigger/hassble/HassBleApp.kt
@@ -1,12 +1,35 @@
 package dev.eigger.hassble
 
 import android.app.Application
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import dev.eigger.hassble.ble.BluetoothAdapterNameGuard
 import dev.eigger.hassble.service.LiveEventLogger
 
 class HassBleApp : Application() {
+    private val bluetoothStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+            val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+            BluetoothAdapterNameGuard.onBluetoothStateChanged(context, state)
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         LiveEventLogger.init(this)
+        BluetoothAdapterNameGuard.resetToInitial(this)
+        val filter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        ContextCompat.registerReceiver(
+            this,
+            bluetoothStateReceiver,
+            filter,
+            ContextCompat.RECEIVER_EXPORTED,
+        )
     }
     // TODO: DI 컨테이너 / 싱글톤(ConfigRepository, MqttTransport, ObdPresetStore) 초기화
 }

--- a/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AdvertisePayload.kt
@@ -5,6 +5,12 @@ import dev.eigger.hassble.config.AdvertisePayloadPhase
 object AdvertisePayload {
     /** legacy 광고 31바이트 - flags AD(3) - AD 헤더(2) - company ID(2) = 24바이트 */
     const val MAX_MANUFACTURER_PAYLOAD = 24
+    const val LEGACY_ADV_MAX = 31
+    const val LEGACY_FLAGS_SIZE = 3
+    const val LEGACY_MANUFACTURER_OVERHEAD = 4
+    const val LEGACY_NAME_OVERHEAD = 2
+    /** BluetoothAdapter.setName 상한 */
+    const val MAX_ADAPTER_NAME_UTF8 = 248
 
     private val TOKEN_REGEX = Regex("""\{(counter|state)(?::([^}]+))?\}""")
 
@@ -76,5 +82,28 @@ object AdvertisePayload {
             }
         }
         return null
+    }
+
+    fun localNameUtf8Size(name: String): Int = name.encodeToByteArray().size
+
+    fun maxRenderedPayloadBytes(template: String, states: List<Int> = listOf(0, 255)): Int? {
+        var max = 0
+        for (c in listOf(0, 255)) {
+            for (s in states) {
+                val bytes = toBytes(render(template, c, s)) ?: return null
+                if (bytes.size > max) max = bytes.size
+            }
+        }
+        return max
+    }
+
+    /** Flags + manufacturer AD + optional Complete Local Name. */
+    fun estimatedLegacyAdvSize(payloadBytes: Int, localName: String?): Int {
+        var size = LEGACY_FLAGS_SIZE + LEGACY_MANUFACTURER_OVERHEAD + payloadBytes
+        val name = localName?.trim().orEmpty()
+        if (name.isNotEmpty()) {
+            size += LEGACY_NAME_OVERHEAD + localNameUtf8Size(name)
+        }
+        return size
     }
 }

--- a/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/AndroidBleAdvertiser.kt
@@ -54,6 +54,10 @@ class AndroidBleAdvertiser(
 
     private val sessions = ConcurrentHashMap<String, Session>()
 
+    init {
+        BluetoothAdapterNameGuard.resetToInitial(context)
+    }
+
     private fun hasAdvertisePermission(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             ContextCompat.checkSelfPermission(
@@ -68,11 +72,35 @@ class AndroidBleAdvertiser(
         }
     }
 
+    private fun hasConnectPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_ADMIN,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun bluetoothAdapter() = context.getSystemService(BluetoothManager::class.java)?.adapter
+
     private fun getBluetoothAdvertiser(): BluetoothLeAdvertiser? {
-        val manager = context.getSystemService(BluetoothManager::class.java) ?: return null
-        val adapter = manager.adapter ?: return null
+        val adapter = bluetoothAdapter() ?: return null
         if (!adapter.isEnabled) return null
         return adapter.bluetoothLeAdvertiser
+    }
+
+    private fun syncAdapterLocalName(): Boolean {
+        val desired = sessions.values.firstNotNullOfOrNull { it.config.resolvedLocalName() }
+        return if (desired != null) {
+            BluetoothAdapterNameGuard.applyOverride(context, desired)
+        } else {
+            BluetoothAdapterNameGuard.resetToInitial(context, force = true)
+        }
     }
 
     // Permission check has already been performed in hasAdvertisePermission() before calling
@@ -113,8 +141,7 @@ class AndroidBleAdvertiser(
 
         val phases = config.payloadPhases
         val initialPhase = phases.firstOrNull()
-        val initialData = buildAdvertiseData(config, counterSeed, initialPhase)
-        if (initialData == null) {
+        if (AdvertisePayload.toBytes(AdvertisePayload.renderPhase(config.payload, counterSeed, initialPhase)) == null) {
             LiveEventLogger.log(
                 LogType.TX,
                 "BLE Advertise failed: invalid payload template '${config.payload}' (device=$deviceId)",
@@ -167,9 +194,10 @@ class AndroidBleAdvertiser(
                     currentSession.advertisingSet = advertisingSet
                     currentSession.isStarted = true
                     val hex = AdvertisePayload.renderPhase(config.payload, currentSession.counter, initialPhase)
+                    val nameNote = config.resolvedLocalName()?.let { ", name='$it'" } ?: ""
                     LiveEventLogger.log(
                         LogType.TX,
-                        "BLE Advertise started: device=$deviceId, txPower=$txPower, hex=$hex",
+                        "BLE Advertise started: device=$deviceId, txPower=$txPower, hex=$hex$nameNote",
                     )
                 } else {
                     val statusText = when (status) {
@@ -222,6 +250,33 @@ class AndroidBleAdvertiser(
         sessionRef = session
         sessions[deviceId] = session
         session.onCounter(session.counter)
+
+        val localName = config.resolvedLocalName()
+        if (localName != null && !syncAdapterLocalName()) {
+            val reason = when {
+                !hasConnectPermission() -> context.getString(R.string.log_advertise_name_no_permission)
+                else -> "BluetoothAdapter.setName('$localName') failed"
+            }
+            LiveEventLogger.log(LogType.TX, "$reason (device=$deviceId)")
+            stop(deviceId, AdvertiseStopReason.Error)
+            return false
+        }
+        if (localName != null) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise local name: device=$deviceId, name='$localName'",
+            )
+        }
+
+        val initialData = buildAdvertiseData(config, counterSeed, initialPhase)
+        if (initialData == null) {
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE Advertise failed: invalid payload template '${config.payload}' (device=$deviceId)",
+            )
+            stop(deviceId, AdvertiseStopReason.Error)
+            return false
+        }
 
         val timeoutMs = parseDurationMs(config.timeout, 15_000)
         val pm = context.getSystemService(PowerManager::class.java)
@@ -311,6 +366,9 @@ class AndroidBleAdvertiser(
         try {
             session.onStopped(reason)
         } finally {
+            if (session.config.resolvedLocalName() != null) {
+                syncAdapterLocalName()
+            }
             val wl = session.wakeLock
             session.wakeLock = null
             if (wl != null && wl.isHeld) {
@@ -367,7 +425,7 @@ class AndroidBleAdvertiser(
         val bytes = AdvertisePayload.toBytes(renderedHex) ?: return null
         return AdvertiseData.Builder()
             .addManufacturerData(config.manufacturerId, bytes)
-            .setIncludeDeviceName(config.includeDeviceName)
+            .setIncludeDeviceName(config.includeNameInAdvertiseData())
             .setIncludeTxPowerLevel(false)
             .build()
     }

--- a/app/src/main/java/dev/eigger/hassble/ble/BluetoothAdapterNameGuard.kt
+++ b/app/src/main/java/dev/eigger/hassble/ble/BluetoothAdapterNameGuard.kt
@@ -1,0 +1,127 @@
+package dev.eigger.hassble.ble
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import dev.eigger.hassble.service.LiveEventLogger
+import dev.eigger.hassble.service.LogType
+
+/**
+ * Android는 광고에 임의 Complete Local Name을 넣는 API가 없고,
+ * Bluetooth 이름을 공장값으로 되돌리는 API도 없다.
+ *
+ * 그래서 이름을 바꾸기 **전에** 당시 값을 SharedPreferences에 초기값으로 남긴다(commit).
+ * 광고가 끝나거나 프로세스가 다시 뜨면 그 초기값으로 setName 한다.
+ * 세션 메모리 백업이 아니라, 디스크 초기값 + 시작 시 초기화다.
+ */
+object BluetoothAdapterNameGuard {
+    private const val PREFS = "hassble_bt_adapter_name"
+    private const val KEY_INITIAL = "initial_name"
+    private const val KEY_OVERRIDDEN = "overridden"
+
+    private val lock = Any()
+
+    /** 이 프로세스에서 지금 광고용 이름으로 바꿔 둔 상태. 강제종료 후에는 false. */
+    @Volatile
+    private var overrideActiveInProcess = false
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    private fun adapter(context: Context) =
+        context.applicationContext.getSystemService(BluetoothManager::class.java)?.adapter
+
+    private fun hasConnectPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context.applicationContext,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            ContextCompat.checkSelfPermission(
+                context.applicationContext,
+                Manifest.permission.BLUETOOTH_ADMIN,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    /**
+     * 초기값을 디스크에 남긴 뒤 [desired]로 바꾼다.
+     * commit이 성공한 다음에만 setName 해서, 그 사이 강제종료돼도 다음 기동에서 초기화할 수 있다.
+     */
+    @SuppressLint("MissingPermission")
+    fun applyOverride(context: Context, desired: String): Boolean {
+        val app = context.applicationContext
+        val bt = adapter(app) ?: return false
+        if (!bt.isEnabled || !hasConnectPermission(app)) return false
+
+        synchronized(lock) {
+            val store = prefs(app)
+            if (!store.getBoolean(KEY_OVERRIDDEN, false)) {
+                val initial = bt.name.orEmpty()
+                val saved = store.edit()
+                    .putString(KEY_INITIAL, initial)
+                    .putBoolean(KEY_OVERRIDDEN, true)
+                    .commit()
+                if (!saved) return false
+            }
+            if (bt.name != desired && !bt.setName(desired)) {
+                return false
+            }
+            overrideActiveInProcess = true
+            return true
+        }
+    }
+
+    /**
+     * 저장해 둔 초기값으로 되돌린다.
+     * [force]가 아니면, 이 프로세스에서 광고 중인 동안에는 건드리지 않는다.
+     * 강제종료 후 재기동은 in-process 플래그가 꺼져 있으므로 prefs의 overridden만 보고 초기화한다.
+     */
+    @SuppressLint("MissingPermission")
+    fun resetToInitial(context: Context, force: Boolean = false): Boolean {
+        if (overrideActiveInProcess && !force) return true
+
+        val app = context.applicationContext
+        synchronized(lock) {
+            val store = prefs(app)
+            if (!store.getBoolean(KEY_OVERRIDDEN, false)) return true
+
+            val initial = store.getString(KEY_INITIAL, null) ?: run {
+                store.edit().putBoolean(KEY_OVERRIDDEN, false).commit()
+                overrideActiveInProcess = false
+                return true
+            }
+
+            val bt = adapter(app)
+            if (bt == null || !bt.isEnabled || !hasConnectPermission(app)) {
+                return false
+            }
+
+            val ok = initial.isEmpty() || bt.name == initial || bt.setName(initial)
+            if (!ok) return false
+
+            store.edit()
+                .putBoolean(KEY_OVERRIDDEN, false)
+                .remove(KEY_INITIAL)
+                .commit()
+            overrideActiveInProcess = false
+            LiveEventLogger.log(
+                LogType.TX,
+                "BLE adapter name reset to initial '$initial'",
+            )
+            return true
+        }
+    }
+
+    fun onBluetoothStateChanged(context: Context, state: Int) {
+        if (state == BluetoothAdapter.STATE_ON) {
+            resetToInitial(context)
+        }
+    }
+}

--- a/app/src/main/java/dev/eigger/hassble/config/Config.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/Config.kt
@@ -171,7 +171,17 @@ data class AdvertiseConfig(
     val connectable: Boolean = false,
     val scannable: Boolean = true,
     @SerialName("include_device_name") val includeDeviceName: Boolean = false,
-)
+    /**
+     * Complete Local Name. Android는 광고에 임의 이름을 넣는 API가 없어
+     * 송신 중에 폰 Bluetooth 이름을 이 값으로 바꾼다.
+     * 바꾸기 전 이름을 디스크에 초기값으로 남기고, 송신 종료·앱 재시작 때 그 값으로 초기화한다.
+     */
+    @SerialName("local_name") val localName: String? = null,
+) {
+    fun resolvedLocalName(): String? = localName?.trim()?.takeIf { it.isNotEmpty() }
+
+    fun includeNameInAdvertiseData(): Boolean = includeDeviceName || resolvedLocalName() != null
+}
 
 /** advertise.payload_phases 한 단계. 카운터는 올리지 않고 state/payload만 바꾼다. */
 @Serializable

--- a/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
+++ b/app/src/main/java/dev/eigger/hassble/config/ConfigValidator.kt
@@ -178,14 +178,58 @@ object ConfigValidator {
                     devicePath(id, "advertise")
                 )
             }
-            if (device.advertise.includeDeviceName) {
+            val phases = device.advertise.payloadPhases
+            val localName = device.advertise.resolvedLocalName()
+            if (device.advertise.localName != null && localName == null) {
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "local_name is empty after trim — ignored",
+                    devicePath(id, "advertise.local_name")
+                )
+            }
+            if (localName != null) {
+                val nameBytes = AdvertisePayload.localNameUtf8Size(localName)
+                if (nameBytes > AdvertisePayload.MAX_ADAPTER_NAME_UTF8) {
+                    issues += ValidationIssue(
+                        ValidationLevel.ERROR, id, null,
+                        "local_name UTF-8 size ($nameBytes bytes) exceeds Bluetooth name limit (${AdvertisePayload.MAX_ADAPTER_NAME_UTF8})",
+                        devicePath(id, "advertise.local_name")
+                    )
+                }
+                val templates = if (phases.isEmpty()) {
+                    listOf(device.advertise.payload)
+                } else {
+                    phases.map { AdvertisePayload.phaseTemplate(device.advertise.payload, it) }
+                }
+                for ((index, template) in templates.withIndex()) {
+                    val payloadBytes = AdvertisePayload.maxRenderedPayloadBytes(template) ?: continue
+                    val total = AdvertisePayload.estimatedLegacyAdvSize(payloadBytes, localName)
+                    if (total > AdvertisePayload.LEGACY_ADV_MAX) {
+                        val path = if (phases.isEmpty()) {
+                            devicePath(id, "advertise.local_name")
+                        } else {
+                            devicePath(id, "advertise.payload_phases[$index]")
+                        }
+                        issues += ValidationIssue(
+                            ValidationLevel.ERROR, id, null,
+                            "local_name '$localName' plus payload would be $total bytes, exceeding the ${AdvertisePayload.LEGACY_ADV_MAX}-byte legacy BLE limit",
+                            path
+                        )
+                    }
+                }
+                issues += ValidationIssue(
+                    ValidationLevel.WARNING, id, null,
+                    "local_name resets the phone Bluetooth name after advertising (and again on next app start if the process was killed)",
+                    devicePath(id, "advertise.local_name")
+                )
+            }
+            if (device.advertise.includeDeviceName && localName == null) {
                 issues += ValidationIssue(
                     ValidationLevel.WARNING, id, null,
                     "include_device_name: true includes device name in advertising data, which may exceed the 31-byte legacy BLE limit",
                     devicePath(id, "advertise.include_device_name")
                 )
             }
-            val phases = device.advertise.payloadPhases
             if (AdvertisePayload.hasStateToken(device.advertise.payload) && phases.isEmpty()) {
                 issues += ValidationIssue(
                     ValidationLevel.ERROR, id, null,

--- a/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
+++ b/app/src/main/java/dev/eigger/hassble/service/BleGatewayService.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import dev.eigger.hassble.R
 import dev.eigger.hassble.ble.BleRuntime
+import dev.eigger.hassble.ble.BluetoothAdapterNameGuard
 import dev.eigger.hassble.ble.DeviceLinkStatus
 import dev.eigger.hassble.ble.haRemoveModeForDevice
 import dev.eigger.hassble.ble.DiscoveredAdvInstance
@@ -75,6 +76,7 @@ class BleGatewayService : Service() {
         _isServiceRunning.value = true
         registerNetworkCallback()
         startForeground(NOTIF_ID, buildNotification())
+        BluetoothAdapterNameGuard.resetToInitial(this)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
+++ b/app/src/main/java/dev/eigger/hassble/ui/MainActivity.kt
@@ -149,6 +149,7 @@ import dev.eigger.hassble.config.ValidationLevel
 import dev.eigger.hassble.config.Source
 import dev.eigger.hassble.ble.DeviceLinkState
 import dev.eigger.hassble.ble.DeviceLinkStatus
+import dev.eigger.hassble.ble.BluetoothAdapterNameGuard
 import dev.eigger.hassble.ble.haRemoveModeForDevice
 import dev.eigger.hassble.net.ConnectionIssue
 import dev.eigger.hassble.net.ConnectionState
@@ -171,6 +172,7 @@ import androidx.lifecycle.lifecycleScope
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        BluetoothAdapterNameGuard.resetToInitial(this)
         handleDeepLink(intent)
         setContent {
             MaterialTheme(
@@ -482,6 +484,7 @@ private fun HomeScreen() {
 
     val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestMultiplePermissions()) {
         refreshPermissions()
+        BluetoothAdapterNameGuard.resetToInitial(context)
     }
     LaunchedEffect(Unit) {
         refreshPermissions()

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -334,6 +334,7 @@
     <string name="device_advertise_stop_btn">중단</string>
     <string name="device_advertising_btn">송신 중…</string>
     <string name="log_advertise_no_permission">BLE 광고 실패: BLUETOOTH_ADVERTISE 권한이 허용되지 않았습니다</string>
+    <string name="log_advertise_name_no_permission">BLE 광고 실패: local_name을 쓰려면 BLUETOOTH_CONNECT 권한이 필요합니다</string>
     <string name="log_advertise_unsupported">이 기기에서 BLE 광고 송신을 지원하지 않습니다</string>
     <string name="github_error_401">인증 실패: GitHub 토큰이 올바르지 않거나 권한이 없습니다 (401).</string>
     <string name="github_error_404">찾을 수 없음: 저장소나 브랜치를 찾을 수 없습니다. 경로를 확인하세요 (404).</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="device_advertise_stop_btn">Stop</string>
     <string name="device_advertising_btn">Advertising…</string>
     <string name="log_advertise_no_permission">BLE advertise failed: BLUETOOTH_ADVERTISE permission not granted</string>
+    <string name="log_advertise_name_no_permission">BLE advertise failed: cannot set local_name without BLUETOOTH_CONNECT</string>
     <string name="log_advertise_unsupported">BLE advertise not supported on this device</string>
     <string name="github_error_401">Unauthorized: GitHub Token is invalid or missing permission.</string>
     <string name="github_error_404">Not Found: Repository or branch not found. Check repository path.</string>

--- a/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/ble/AdvertisePayloadTest.kt
@@ -110,6 +110,13 @@ class AdvertisePayloadTest {
     }
 
     @Test
+    fun testEstimatedLegacyAdvSizeWithAptSmartKey() {
+        assertEquals(27, AdvertisePayload.estimatedLegacyAdvSize(6, "APT SmartKey"))
+        assertEquals(13, AdvertisePayload.estimatedLegacyAdvSize(6, null))
+        assertEquals(6, AdvertisePayload.maxRenderedPayloadBytes("02050064{state:02X}{counter:02X}"))
+    }
+
+    @Test
     fun testValidationErrorWithStateToken() {
         assertNull(AdvertisePayload.validationError("02050064{state:02X}{counter:02X}"))
     }

--- a/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
+++ b/app/src/test/java/dev/eigger/hassble/config/AdvertiseConfigTest.kt
@@ -332,4 +332,58 @@ class AdvertiseConfigTest {
         val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("duration") }
         assertNotNull(err)
     }
+
+    @Test
+    fun testParseLocalNameYaml() {
+        val yaml = """
+        devices:
+          - id: parking_beacon
+            name: "Parking Beacon"
+            source: advertisement
+            advertise:
+              manufacturer_id: 861
+              payload: "02050064{state:02X}{counter:02X}"
+              local_name: "APT SmartKey"
+              payload_phases:
+                - state: 65
+                  duration: 200ms
+                - state: 64
+                  duration: 3s
+            controls:
+              - key: request_location
+                type: button
+                action: advertise
+        """.trimIndent()
+
+        val config = Yaml.default.decodeFromString(GatewayConfig.serializer(), yaml)
+        val adv = config.devices[0].advertise
+        assertNotNull(adv)
+        assertEquals("APT SmartKey", adv!!.localName)
+        assertEquals("APT SmartKey", adv.resolvedLocalName())
+        assertTrue(adv.includeNameInAdvertiseData())
+
+        val issues = ConfigValidator.validate(config)
+        assertTrue("Expected no ERROR issues, but got: $issues", issues.none { it.level == ValidationLevel.ERROR })
+        val warn = issues.firstOrNull { it.level == ValidationLevel.WARNING && it.message.contains("local_name resets") }
+        assertNotNull(warn)
+    }
+
+    @Test
+    fun testLocalNameTooLongForLegacyAdv() {
+        val device = DeviceConfig(
+            id = "test",
+            name = "Test",
+            source = Source.advertisement,
+            instanceMode = AdvertisementInstanceMode.shared,
+            advertise = AdvertiseConfig(
+                manufacturerId = 861,
+                payload = "020500640000",
+                localName = "THIS NAME IS WAY TOO LONG FOR BLE",
+            ),
+            controls = listOf(ControlConfig(key = "req", type = ControlType.button, action = ControlAction.advertise)),
+        )
+        val issues = ConfigValidator.validate(GatewayConfig(devices = listOf(device)))
+        val err = issues.firstOrNull { it.level == ValidationLevel.ERROR && it.message.contains("31-byte legacy BLE limit") }
+        assertNotNull(err)
+    }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,6 +84,7 @@ devices:
   #     stop_on_response: true           # 06 응답 수신 시 즉시 송신 중단
   #     connectable: false
   #     scannable: true
+  #     # local_name: "APT SmartKey"     # Complete Local Name. 송신 중 이 이름으로 바꾸고, 종료·재시작 때 초기값으로 되돌림
   #   controls:
   #     - key: request_location
   #       type: button

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -106,6 +106,8 @@ devices: [ ... ]                    # 아래 참조
     stop_on_response: true           # 이 프로필 광고(match)를 수신하면 즉시 송신 중단
     connectable: false
     scannable: true
+    # local_name: "APT SmartKey"     # Complete Local Name. 송신 중 이 이름으로 바꾸고, 종료·재시작 때 초기값으로 되돌림
+    # include_device_name: false     # local_name이 있으면 자동으로 이름 AD를 포함
   controls:
     - key: request_location
       type: button
@@ -128,7 +130,8 @@ devices: [ ... ]                    # 아래 참조
 | `stop_on_response` | | `true` | 이 프로필의 `match` 조건을 만족하는 광고 패킷 수신 시 즉시 광고 송신 중단 |
 | `connectable` | | `false` | BLE 연결 가능 여부 |
 | `scannable` | | `true` | Scannable 광고 여부 |
-| `include_device_name` | | `false` | 광고 패킷에 기기 이름 포함 여부 (31바이트 예산 절약을 위해 기본 false) |
+| `include_device_name` | | `false` | 광고 패킷에 현재 폰 Bluetooth 이름 포함. `local_name`이 있으면 자동으로 포함되므로 따로 켤 필요 없음 |
+| `local_name` | | `null` | Complete Local Name (예: `APT SmartKey`). Android는 광고에 임의 이름을 넣는 API가 없어, 송신 중에 폰 Bluetooth 이름을 이 값으로 바꾼다. 바꾸기 전 이름을 디스크에 초기값으로 남기고, 송신 종료나 앱 재시작(강제종료 포함) 때 그 값으로 초기화한다. 31바이트 legacy 한도를 넘으면 오류 |
 
 > **알림:** `advertise` 블록이 설정된 기기는 HA에 `{id}_advertising` 진단 바이너리 센서(`binary_sensor`)가 자동으로 생성되어 현재 광고 송신 진행 여부를 보고합니다.
 


### PR DESCRIPTION
## Summary
- `advertise.local_name`로 BLE Complete Local Name을 설정에서 지정합니다. Android는 광고에 임의 이름을 넣는 API가 없어, 송신 중에 폰 Bluetooth 이름을 바꿉니다.
- 바꾸기 전 이름을 디스크에 초기값으로 남기고, 송신 종료나 앱 재시작(강제종료 포함) 때 그 값으로 초기화합니다.
- 버전을 1.4.1 (versionCode 68)으로 올렸습니다.

## Test plan
- [ ] unit test: AdvertisePayloadTest, AdvertiseConfigTest
- [ ] parking_beacon local_name APT SmartKey — 송신 중 스캔에 해당 이름이 보임
- [ ] 송신 종료 후 폰 Bluetooth 이름이 원래대로 돌아옴
- [ ] 송신 중 앱 강제종료 후 재실행 시에도 원래 이름으로 초기화됨
- [ ] local_name 없는 기존 advertise 프로필은 이전과 동일
